### PR TITLE
Update service details and add blog section

### DIFF
--- a/src/components/BlogSection.tsx
+++ b/src/components/BlogSection.tsx
@@ -1,0 +1,71 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+const posts = [
+  {
+    city: 'Zvolen',
+    title: 'Prvý večer vo Zvolene: zámok, námestie a lokálne bary',
+    excerpt:
+      'Spojte si kultúru s oddychom – navštívte Zvolenský zámok, prejdite sa po Námestí SNP a zakončite večer v baroch Quadra alebo Retro.',
+    highlights: ['Historické centrum', 'Craft koktaily', 'Nočné taxi späť na základňu'],
+    readTime: '4 min čítanie',
+  },
+  {
+    city: 'Banská Bystrica',
+    title: 'Banskobystrická večerná scéna pre španielsky kontingent',
+    excerpt:
+      'Europa SC, námestie a ulice plné podnikov – Ministry of Fun, Klub 77 či Bar Murgaš ponúkajú hudbu aj zázemie pre väčšie skupiny.',
+    highlights: ['Nightlife odporúčania', 'Bezpečný presun', 'Rezervácie pre skupiny'],
+    readTime: '5 min čítanie',
+  },
+  {
+    city: 'Gastro tipy',
+    title: 'Reštaurácie so stredomorským menu a neskorou kuchyňou',
+    excerpt:
+      'Skúste tapas v Bistro Chef vo Zvolene, talianske klasiky v Alžbete a slovenské špeciality v Bystrickej Klubovni – všetko overené komunitou.',
+    highlights: ['Tapas & víno', 'Otvorené po 22:00', 'Možnosť rezervácie stolov'],
+    readTime: '3 min čítanie',
+  },
+];
+
+const BlogSection = () => {
+  return (
+    <section className="py-20 px-6 bg-gradient-to-b from-muted/40 via-background to-muted/40">
+      <div className="max-w-6xl mx-auto space-y-12">
+        <div className="text-center space-y-4">
+          <h2 className="text-4xl md:text-5xl font-bold text-gradient-gold">Blog TaxiForce</h2>
+          <p className="text-lg text-muted-foreground max-w-3xl mx-auto">
+            Aktuálne tipy pre voľný čas v mestách Zvolen a Banská Bystrica vrátane barov, reštaurácií a kultúrnych zastávok.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+          {posts.map((post) => (
+            <Card
+              key={post.title}
+              className="bg-card/60 backdrop-blur border border-secondary/20 hover:border-secondary/50 transition-all duration-300"
+            >
+              <CardHeader className="space-y-2">
+                <span className="text-xs uppercase tracking-wide text-secondary">{post.city}</span>
+                <CardTitle className="text-xl text-foreground">{post.title}</CardTitle>
+                <span className="text-xs text-muted-foreground">{post.readTime}</span>
+              </CardHeader>
+              <CardContent className="space-y-4 text-sm text-muted-foreground">
+                <p>{post.excerpt}</p>
+                <ul className="space-y-1">
+                  {post.highlights.map((item) => (
+                    <li key={item} className="flex items-center gap-2">
+                      <span className="text-secondary">•</span>
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default BlogSection;

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -29,6 +29,12 @@ const ContactSection = () => {
               <p className="text-lg text-muted-foreground">
                 Hovoriť: English
               </p>
+              <p className="text-sm text-muted-foreground mt-2">
+                Priemerný čas príchodu vozidla je 30 – 40 minút.
+              </p>
+              <p className="text-sm font-semibold text-secondary mt-1">
+                Platba je možná len v hotovosti v eurách.
+              </p>
             </div>
 
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -46,14 +52,13 @@ const ContactSection = () => {
                   📞 Zavolať teraz
                 </a>
               </Button>
-              
-              <Button 
-                variant="outline" 
+
+              <Button
                 size="lg"
                 className="
-                  border-2 border-secondary text-secondary 
-                  hover:bg-secondary hover:text-secondary-foreground
-                  font-bold py-4 rounded-full backdrop-blur-md
+                  bg-[#25D366] text-white
+                  hover:bg-[#1ebe5d]
+                  font-bold py-4 rounded-full shadow-xl
                 "
                 asChild
               >

--- a/src/components/FeaturesSection.tsx
+++ b/src/components/FeaturesSection.tsx
@@ -9,7 +9,7 @@ const features = [
     icon: '🚐',
     title: 'Priame spojenie Lešť → Zvolen / Banská Bystrica',
     description:
-      'Monitorujeme pohyb jednotiek a koordinujeme vyzdvihnutia priamo pri bráne základne. Typická cesta trvá 30 – 45 minút.',
+      'Monitorujeme pohyb jednotiek a koordinujeme vyzdvihnutia priamo pri bráne základne. Vozidlo štandardne dorazí do 30 – 40 minút.',
     image: taxiImage,
     badge: 'Non-stop dispečing',
   },
@@ -33,9 +33,17 @@ const features = [
     icon: '🌙',
     title: 'Operácie 24/7 vrátane neskorých návratov',
     description:
-      'Služba pokrýva nočné vychádzky aj skoré ranné presuny na cvičenia. Čakací čas do 30 minút je zahrnutý v cene.',
+      'Služba pokrýva nočné vychádzky aj skoré ranné presuny na cvičenia. Čakanie sa dohodne individuálne podľa tarify.',
     image: cityImage,
     badge: 'Night ready',
+  },
+  {
+    icon: '💶',
+    title: 'Platba výlučne v hotovosti',
+    description:
+      'Fakturácia je jednoduchá a transparentná – platíte pri nástupe v eurách, bez možnosti kartovej platby.',
+    image: null,
+    badge: 'Payment info',
   },
   {
     icon: '🇪🇸',
@@ -44,14 +52,6 @@ const features = [
       'Dispečing rozumie vojenským termínom, vodiči sú pripravení komunikovať v angličtine a najčastejších frázach po španielsky.',
     image: null,
     badge: 'Language support',
-  },
-  {
-    icon: '🔁',
-    title: 'Garancia spiatočného spojenia',
-    description:
-      'Vopred rezervované časy odchodu späť na základňu. V prípade zmeny rozkazov bezplatne upravíme itinerár.',
-    image: null,
-    badge: 'Flexible',
   },
 ];
 

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -40,8 +40,8 @@ const HeroSection = () => {
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-10 text-left text-sm sm:text-base">
           {[{
             title: 'Priemerný čas príchodu',
-            value: '8 minút',
-            note: 'Non-stop dispečing priamo na základni',
+            value: '30 – 40 minút',
+            note: 'Non-stop dispečing potvrdzuje dostupnosť v reálnom čase',
           },
           {
             title: 'Kapacita jedného vozidla',
@@ -49,9 +49,9 @@ const HeroSection = () => {
             note: 'Luxusné SUV alebo business sedan',
           },
           {
-            title: 'Rezervácie',
-            value: 'Telefonicky alebo WhatsApp',
-            note: '+421 919 040 118',
+            title: 'Platba',
+            value: 'Len v hotovosti',
+            note: 'Prosíme pripraviť si sumu pred odjazdom',
           }].map((item, index) => (
             <div
               key={item.title}
@@ -82,13 +82,12 @@ const HeroSection = () => {
           </Button>
 
           <Button
-            variant="outline"
             size="lg"
             className="
-              bg-background/40 border-2 border-secondary text-secondary
-              hover:bg-secondary hover:text-secondary-foreground
-              px-8 py-4 text-lg font-semibold rounded-full backdrop-blur-md
-              transition-all duration-300
+              bg-[#25D366] text-white
+              hover:bg-[#1ebe5d]
+              px-8 py-4 text-lg font-semibold rounded-full
+              shadow-xl transition-all duration-300
             "
             asChild
           >

--- a/src/components/PricingSection.tsx
+++ b/src/components/PricingSection.tsx
@@ -39,7 +39,7 @@ const PricingSection = () => {
             <CardContent className="space-y-4">
 
               <div className="text-left space-y-3">
-                {["✅ 25% vojenská zľava už aplikovaná", "✅ Čakací čas zahrnutý (až 30 min)", "✅ Garantovaná spiatočná cesta", "✅ Prémiové vozidlo", "✅ Vodič hovoriaci iba po anglicky", "✅ Bezpečnostné overenie NATO", "✅ Diskrétna služba 24/7"].map((feature, index) => <div key={index} className="flex items-center gap-3">
+                {["✅ 25% vojenská zľava už aplikovaná", "✅ Priemerný čas príchodu 30 – 40 min podľa dostupnosti", "✅ Garantovaná spiatočná cesta", "✅ Prémiové vozidlo", "✅ Vodič hovoriaci iba po anglicky", "✅ Bezpečnostné overenie NATO", "✅ Platba výlučne v hotovosti"].map((feature, index) => <div key={index} className="flex items-center gap-3">
                     <span className="text-secondary">{feature.split(' ')[0]}</span>
                     <span className="text-foreground">{feature.substring(2)}</span>
                   </div>)}
@@ -86,7 +86,7 @@ const PricingSection = () => {
             <CardContent className="space-y-4">
 
               <div className="text-left space-y-3">
-                {["✅ 25% vojenská zľava už aplikovaná", "✅ Čakací čas zahrnutý (až 30 min)", "✅ Garantovaná spiatočná cesta", "✅ Prémiové vozidlo", "✅ Vodič hovoriaci iba po anglicky", "✅ Bezpečnostné overenie NATO", "✅ Diskrétna služba 24/7"].map((feature, index) => <div key={index} className="flex items-center gap-3">
+                {["✅ 25% vojenská zľava už aplikovaná", "✅ Priemerný čas príchodu 30 – 40 min podľa dostupnosti", "✅ Garantovaná spiatočná cesta", "✅ Prémiové vozidlo", "✅ Vodič hovoriaci iba po anglicky", "✅ Bezpečnostné overenie NATO", "✅ Platba výlučne v hotovosti"].map((feature, index) => <div key={index} className="flex items-center gap-3">
                     <span className="text-secondary">{feature.split(' ')[0]}</span>
                     <span className="text-foreground">{feature.substring(2)}</span>
                   </div>)}
@@ -122,4 +122,5 @@ const PricingSection = () => {
       </div>
     </section>;
 };
+
 export default PricingSection;

--- a/src/components/RouteSection.tsx
+++ b/src/components/RouteSection.tsx
@@ -5,12 +5,12 @@ const routes = [
   {
     title: 'Lešť → Zvolen',
     duration: '35 min',
-    highlights: ['Priamy vstup cez vojenskú bránu', 'Čakáme počas večere až 60 min', 'Odporúčané bary: Quadra, Retro'],
+    highlights: ['Priamy vstup cez vojenskú bránu', 'Koordinácia vyzdvihnutia bez zbytočného čakania', 'Odporúčané bary: Quadra, Retro'],
   },
   {
     title: 'Lešť → Banská Bystrica',
     duration: '50 min',
-    highlights: ['Transfer na Námestie SNP a Europa Shopping Center', 'Koordinácia s nočnými klubmi Ministry, Klub 77', 'Dohodnuté návraty na presný čas'],
+    highlights: ['Transfer na Námestie SNP a Europa Shopping Center', 'Koordinácia s nočnými klubmi Ministry, Klub 77', 'Platba výlučne v hotovosti pri nástupe'],
   },
 ];
 

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
   return (

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -7,6 +7,7 @@ import PricingSection from '@/components/PricingSection';
 import FaqSection from '@/components/FaqSection';
 import SeoContentSection from '@/components/SeoContentSection';
 import ContactSection from '@/components/ContactSection';
+import BlogSection from '@/components/BlogSection';
 
 const Index = () => {
   return (
@@ -20,6 +21,7 @@ const Index = () => {
         <TestimonialsSection />
         <FaqSection />
         <SeoContentSection />
+        <BlogSection />
         <ContactSection />
       </main>
     </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
   darkMode: ["class"],
@@ -93,5 +94,5 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- update customer messaging to reflect 30–40 min arrival times and cash-only payments, and refresh WhatsApp buttons with the correct green styling
- expand marketing content by replacing outdated waiting-time mentions, refining route highlights, and adding a blog section covering Zvolen and Banská Bystrica venues
- clean up tooling by switching the tailwind plugin import to ESM and resolving lint errors from empty interface extensions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4478bf1b883239e7e10b81f1947ca