### PR TITLE
Prispôsobiť mobilné zobrazenie a zmenšiť prvky

### DIFF
--- a/src/components/BlogSection.tsx
+++ b/src/components/BlogSection.tsx
@@ -29,27 +29,27 @@ const posts = [
 
 const BlogSection = () => {
   return (
-    <section className="py-20 px-6 bg-gradient-to-b from-muted/40 via-background to-muted/40">
-      <div className="max-w-6xl mx-auto space-y-12">
-        <div className="text-center space-y-4">
-          <h2 className="text-4xl md:text-5xl font-bold text-gradient-gold">Blog TaxiForce</h2>
-          <p className="text-lg text-muted-foreground max-w-3xl mx-auto">
+    <section className="py-16 sm:py-20 px-4 sm:px-6 bg-gradient-to-b from-muted/40 via-background to-muted/40">
+      <div className="max-w-6xl mx-auto space-y-10 sm:space-y-12">
+        <div className="text-center space-y-3 sm:space-y-4">
+          <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold text-gradient-gold">Blog TaxiForce</h2>
+          <p className="text-base sm:text-lg text-muted-foreground max-w-3xl mx-auto">
             Aktuálne tipy pre voľný čas v mestách Zvolen a Banská Bystrica vrátane barov, reštaurácií a kultúrnych zastávok.
           </p>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+        <div className="grid grid-cols-1 min-[420px]:grid-cols-2 md:grid-cols-3 gap-4 sm:gap-6 md:gap-8">
           {posts.map((post) => (
             <Card
               key={post.title}
               className="bg-card/60 backdrop-blur border border-secondary/20 hover:border-secondary/50 transition-all duration-300"
             >
-              <CardHeader className="space-y-2">
-                <span className="text-xs uppercase tracking-wide text-secondary">{post.city}</span>
-                <CardTitle className="text-xl text-foreground">{post.title}</CardTitle>
-                <span className="text-xs text-muted-foreground">{post.readTime}</span>
+              <CardHeader className="space-y-1.5 sm:space-y-2">
+                <span className="text-[11px] sm:text-xs uppercase tracking-wide text-secondary">{post.city}</span>
+                <CardTitle className="text-lg sm:text-xl text-foreground">{post.title}</CardTitle>
+                <span className="text-[11px] sm:text-xs text-muted-foreground">{post.readTime}</span>
               </CardHeader>
-              <CardContent className="space-y-4 text-sm text-muted-foreground">
+              <CardContent className="space-y-3 sm:space-y-4 text-xs sm:text-sm text-muted-foreground">
                 <p>{post.excerpt}</p>
                 <ul className="space-y-1">
                   {post.highlights.map((item) => (

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent } from '@/components/ui/card';
 
 const ContactSection = () => {
   return (
-    <section className="py-20 px-6 bg-gradient-to-t from-primary/10 via-background to-secondary/5 relative overflow-hidden">
+    <section className="py-16 sm:py-20 px-4 sm:px-6 bg-gradient-to-t from-primary/10 via-background to-secondary/5 relative overflow-hidden">
       {/* Spanish flag pattern background */}
       <div className="absolute inset-0 opacity-10">
         <div className="absolute top-0 left-0 w-full h-1/3 bg-primary" />
@@ -12,38 +12,38 @@ const ContactSection = () => {
       </div>
 
       <div className="relative z-10 max-w-4xl mx-auto text-center">
-        <h2 className="text-4xl md:text-5xl font-bold mb-4 text-gradient-gold">
+        <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-3 sm:mb-4 text-gradient-gold">
           Kontakt a rezervácie
         </h2>
-        <p className="text-xl text-muted-foreground mb-12 max-w-2xl mx-auto">
+        <p className="text-base sm:text-lg md:text-xl text-muted-foreground mb-8 sm:mb-12 max-w-2xl mx-auto">
           Kontaktujte nás pre okamžité vyzdvihnutie alebo rezervujte dopredu.<br />
           Naši profesionálni vodiči sú k dispozícii 24/7.
         </p>
 
-        <Card className="bg-card/50 backdrop-blur-md border border-secondary/30 p-8 mb-8">
-          <CardContent className="space-y-6">
+        <Card className="bg-card/50 backdrop-blur-md border border-secondary/30 p-5 sm:p-8 mb-6 sm:mb-8">
+          <CardContent className="space-y-5 sm:space-y-6">
             <div className="text-center">
-              <div className="text-5xl md:text-6xl font-black text-gradient-gold mb-4">
+              <div className="text-4xl sm:text-5xl md:text-6xl font-black text-gradient-gold mb-3 sm:mb-4">
                 📞 +421919040118
               </div>
-              <p className="text-lg text-muted-foreground">
+              <p className="text-base sm:text-lg text-muted-foreground">
                 Hovoriť: English
               </p>
-              <p className="text-sm text-muted-foreground mt-2">
+              <p className="text-xs sm:text-sm text-muted-foreground mt-2">
                 Priemerný čas príchodu vozidla je 30 – 40 minút.
               </p>
-              <p className="text-sm font-semibold text-secondary mt-1">
+              <p className="text-xs sm:text-sm font-semibold text-secondary mt-1">
                 Platba je možná len v hotovosti v eurách.
               </p>
             </div>
 
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <Button 
-                size="lg" 
+            <div className="grid grid-cols-1 min-[420px]:grid-cols-2 gap-3 sm:gap-4">
+              <Button
+                size="lg"
                 className="
-                  bg-gradient-to-r from-primary to-primary-glow 
-                  hover:from-primary-glow hover:to-primary 
-                  text-primary-foreground font-bold py-4
+                  bg-gradient-to-r from-primary to-primary-glow
+                  hover:from-primary-glow hover:to-primary
+                  text-primary-foreground font-bold py-3 sm:py-4 text-base sm:text-lg
                   rounded-full shadow-xl hover-military
                 "
                 asChild
@@ -58,7 +58,7 @@ const ContactSection = () => {
                 className="
                   bg-[#25D366] text-white
                   hover:bg-[#1ebe5d]
-                  font-bold py-4 rounded-full shadow-xl
+                  font-bold py-3 sm:py-4 text-base sm:text-lg rounded-full shadow-xl
                 "
                 asChild
               >
@@ -70,11 +70,11 @@ const ContactSection = () => {
           </CardContent>
         </Card>
 
-        <div className="bg-primary/10 backdrop-blur-md border border-primary/30 rounded-xl p-6 mb-8">
-          <p className="text-lg font-semibold text-primary mb-4">
+        <div className="bg-primary/10 backdrop-blur-md border border-primary/30 rounded-xl p-4 sm:p-6 mb-6 sm:mb-8">
+          <p className="text-base sm:text-lg font-semibold text-primary mb-3 sm:mb-4">
             📱 Dostupné 24/7 pre vaše prepravné potreby
           </p>
-          <div className="flex justify-center gap-4 text-sm">
+          <div className="flex justify-center gap-3 sm:gap-4 text-xs sm:text-sm">
             <span className="text-secondary font-medium">⏰ Dostupné 24/7</span>
             <span className="text-muted-foreground">•</span>
             <span className="text-secondary font-medium">🔒 Diskrétne</span>
@@ -84,27 +84,27 @@ const ContactSection = () => {
         </div>
 
         <div className="text-center space-y-4">
-          <h3 className="text-2xl font-bold text-secondary">Naše výhody</h3>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 max-w-2xl mx-auto">
+          <h3 className="text-xl sm:text-2xl font-bold text-secondary">Naše výhody</h3>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 sm:gap-4 max-w-2xl mx-auto">
             {[
               { icon: "🛡️", text: "NATO bezpečnosť" },
               { icon: "🚗", text: "Prémiové vozidlá" },
               { icon: "👨‍✈️", text: "Vojenský personál" },
               { icon: "⭐", text: "Top hodnotenie" }
             ].map((item, index) => (
-              <div 
+              <div
                 key={index}
-                className="text-center p-4 bg-secondary/5 rounded-lg border border-secondary/20"
+                className="text-center p-3 sm:p-4 bg-secondary/5 rounded-lg border border-secondary/20"
               >
-                <div className="text-2xl mb-2">{item.icon}</div>
-                <div className="text-sm font-medium text-muted-foreground">{item.text}</div>
+                <div className="text-xl sm:text-2xl mb-1.5 sm:mb-2">{item.icon}</div>
+                <div className="text-xs sm:text-sm font-medium text-muted-foreground">{item.text}</div>
               </div>
             ))}
           </div>
         </div>
 
-        <div className="mt-12 text-center">
-          <p className="text-sm text-muted-foreground">
+        <div className="mt-10 sm:mt-12 text-center">
+          <p className="text-xs sm:text-sm text-muted-foreground">
             TaxiForce s.r.o. • Licencia: SK-TAXI-2024 • Registrované na Ministerstve dopravy SR
           </p>
         </div>

--- a/src/components/FaqSection.tsx
+++ b/src/components/FaqSection.tsx
@@ -29,27 +29,27 @@ const faqs = [
 
 const FaqSection = () => {
   return (
-    <section className="py-20 px-6 bg-gradient-to-br from-secondary/5 via-background to-primary/5">
+    <section className="py-16 sm:py-20 px-4 sm:px-6 bg-gradient-to-br from-secondary/5 via-background to-primary/5">
       <div className="max-w-4xl mx-auto">
-        <div className="text-center mb-12 space-y-3">
-          <h2 className="text-4xl md:text-5xl font-bold text-gradient-military">Najčastejšie otázky</h2>
-          <p className="text-lg text-muted-foreground">
+        <div className="text-center mb-10 sm:mb-12 space-y-2.5 sm:space-y-3">
+          <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold text-gradient-military">Najčastejšie otázky</h2>
+          <p className="text-base sm:text-lg text-muted-foreground">
             Transparentne komunikujeme v slovenčine, angličtine aj španielčine. Tu sú najčastejšie otázky španielskej jednotky.
           </p>
         </div>
 
-        <Accordion type="single" collapsible className="space-y-4">
+        <Accordion type="single" collapsible className="space-y-3 sm:space-y-4">
           {faqs.map((faq, index) => (
             <AccordionItem
               key={faq.question}
               value={`faq-${index}`}
               className="border border-secondary/30 rounded-2xl overflow-hidden bg-card/60 backdrop-blur"
             >
-              <AccordionTrigger className="px-6 text-left text-base sm:text-lg font-semibold text-secondary">
+              <AccordionTrigger className="px-4 sm:px-6 text-left text-base sm:text-lg font-semibold text-secondary">
                 {faq.question}
               </AccordionTrigger>
-              <AccordionContent className="px-6 pb-6 space-y-3">
-                <p className="text-sm sm:text-base text-muted-foreground leading-relaxed">{faq.answer}</p>
+              <AccordionContent className="px-4 sm:px-6 pb-4 sm:pb-6 space-y-2.5 sm:space-y-3">
+                <p className="text-sm text-muted-foreground leading-relaxed">{faq.answer}</p>
                 <p className="text-xs sm:text-sm text-secondary/80 italic">{faq.translation}</p>
               </AccordionContent>
             </AccordionItem>

--- a/src/components/FeaturesSection.tsx
+++ b/src/components/FeaturesSection.tsx
@@ -57,18 +57,18 @@ const features = [
 
 const FeaturesSection = () => {
   return (
-    <section className="py-20 px-6 bg-gradient-to-b from-background to-muted">
+    <section className="py-14 sm:py-20 px-4 sm:px-6 bg-gradient-to-b from-background to-muted">
       <div className="max-w-7xl mx-auto">
-        <div className="text-center mb-16">
-          <h2 className="text-4xl md:text-5xl font-bold mb-4 text-gradient-gold">
+        <div className="text-center mb-12 sm:mb-16">
+          <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-3 sm:mb-4 text-gradient-gold">
             Prečo zvoliť TaxiForce?
           </h2>
-          <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
+          <p className="text-base sm:text-lg md:text-xl text-muted-foreground max-w-3xl mx-auto">
             Špecializovaná prepravná jednotka pre španielsky vojenský personál pôsobiaci na základni Lešť
           </p>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+        <div className="grid grid-cols-1 min-[420px]:grid-cols-2 md:grid-cols-3 xl:grid-cols-4 gap-4 sm:gap-6 md:gap-8">
           {features.map((feature, index) => (
             <Card
               key={feature.title}
@@ -80,33 +80,33 @@ const FeaturesSection = () => {
               style={{ animationDelay: `${index * 0.1}s` }}
             >
               {feature.badge && (
-                <span className="absolute top-4 right-4 text-[10px] font-bold tracking-widest uppercase bg-secondary/20 text-secondary px-2 py-1 rounded-full border border-secondary/40">
+                <span className="absolute top-3 right-3 text-[9px] sm:text-[10px] font-bold tracking-widest uppercase bg-secondary/20 text-secondary px-1.5 sm:px-2 py-1 rounded-full border border-secondary/40">
                   {feature.badge}
                 </span>
               )}
 
-              <CardContent className="p-6 space-y-4">
+              <CardContent className="p-4 sm:p-6 space-y-3 sm:space-y-4">
                 {feature.image && (
                   <div
-                    className="w-full h-32 bg-cover bg-center rounded-lg border border-secondary/20"
+                    className="w-full h-24 sm:h-32 bg-cover bg-center rounded-lg border border-secondary/20"
                     style={{ backgroundImage: `url(${feature.image})` }}
                   />
                 )}
 
-                <div className="text-center space-y-3">
-                  <div className="text-4xl group-hover:scale-110 transition-transform duration-300">
+                <div className="text-center space-y-2.5 sm:space-y-3">
+                  <div className="text-3xl sm:text-4xl group-hover:scale-110 transition-transform duration-300">
                     {feature.icon}
                   </div>
 
-                  <h3 className="text-xl font-bold text-secondary leading-snug">
+                  <h3 className="text-lg sm:text-xl font-bold text-secondary leading-snug">
                     {feature.title}
                   </h3>
 
-                  <p className="text-sm text-muted-foreground leading-relaxed">
+                  <p className="text-xs sm:text-sm text-muted-foreground leading-relaxed">
                     {feature.description}
                   </p>
 
-                  <div className="h-1 bg-gradient-to-r from-primary via-secondary to-primary mt-4 rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+                  <div className="h-1 bg-gradient-to-r from-primary via-secondary to-primary mt-3 sm:mt-4 rounded-full opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
                 </div>
               </CardContent>
             </Card>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -17,27 +17,27 @@ const HeroSection = () => {
     >
       <div className="absolute inset-0 bg-gradient-to-b from-black/40 via-black/50 to-black/80" />
 
-      <div className="relative z-10 max-w-5xl px-6 py-20">
-        <div className="flex flex-wrap items-center justify-center gap-3 mb-8">
-          <span className="bg-gradient-to-r from-primary to-secondary px-4 py-2 rounded-full text-xs sm:text-sm font-bold uppercase tracking-wide shadow-lg">
+      <div className="relative z-10 max-w-5xl px-4 sm:px-6 py-16 sm:py-24">
+        <div className="flex flex-wrap items-center justify-center gap-2 sm:gap-3 mb-6 sm:mb-8">
+          <span className="bg-gradient-to-r from-primary to-secondary px-3 py-1.5 sm:px-4 sm:py-2 rounded-full text-[11px] sm:text-xs font-bold uppercase tracking-wide shadow-lg">
             🇪🇸 Base Training Area Lešť → Zvolen / Banská Bystrica
           </span>
-          <span className="bg-secondary/10 border border-secondary/40 text-secondary px-3 py-1 rounded-full text-xs sm:text-sm font-semibold backdrop-blur">
+          <span className="bg-secondary/10 border border-secondary/40 text-secondary px-3 py-1 rounded-full text-[11px] sm:text-xs font-semibold backdrop-blur">
             Overené NATO • Diskrétne 24/7
           </span>
         </div>
 
-        <h1 className="text-4xl md:text-6xl xl:text-7xl font-black mb-6 text-gradient-military drop-shadow-2xl leading-tight">
+        <h1 className="text-3xl sm:text-5xl md:text-6xl xl:text-7xl font-black mb-5 sm:mb-6 text-gradient-military drop-shadow-2xl leading-tight">
           TaxiForce Military Transfers
         </h1>
 
-        <p className="text-lg md:text-2xl mb-10 text-foreground/90 max-w-3xl mx-auto leading-relaxed">
+        <p className="text-base sm:text-lg md:text-2xl mb-8 sm:mb-10 text-foreground/90 max-w-3xl mx-auto leading-relaxed">
           Prémiová preprava pre španielsky vojenský personál na Slovensku. Rýchle transfery zo základne Lešť do Zvolena a Banskej Bystrice, bezpečné návraty späť.
           <br className="hidden md:block" />
           <span className="text-secondary font-semibold">Servicio disponible también en español bajo požiadavke.</span>
         </p>
 
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-10 text-left text-sm sm:text-base">
+        <div className="grid grid-cols-1 min-[420px]:grid-cols-2 sm:grid-cols-3 gap-3 sm:gap-4 mb-8 sm:mb-10 text-left text-xs sm:text-sm">
           {[{
             title: 'Priemerný čas príchodu',
             value: '30 – 40 minút',
@@ -55,23 +55,23 @@ const HeroSection = () => {
           }].map((item, index) => (
             <div
               key={item.title}
-              className="bg-black/30 border border-secondary/20 rounded-xl p-4 sm:p-5 backdrop-blur hover:border-secondary/40 transition-all duration-300"
+              className="bg-black/30 border border-secondary/20 rounded-xl p-3 sm:p-5 backdrop-blur hover:border-secondary/40 transition-all duration-300"
               style={{ animationDelay: `${index * 0.1}s` }}
             >
-              <p className="text-secondary text-xs uppercase tracking-wide mb-1">{item.title}</p>
-              <p className="text-xl font-bold text-foreground">{item.value}</p>
-              <p className="text-muted-foreground text-sm">{item.note}</p>
+              <p className="text-secondary text-[11px] sm:text-xs uppercase tracking-wide mb-1">{item.title}</p>
+              <p className="text-lg sm:text-xl font-bold text-foreground">{item.value}</p>
+              <p className="text-muted-foreground text-xs sm:text-sm leading-relaxed">{item.note}</p>
             </div>
           ))}
         </div>
 
-        <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+        <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center items-center">
           <Button
             size="lg"
             className="
               bg-gradient-to-r from-primary to-primary-glow
               hover:from-primary-glow hover:to-primary
-              text-primary-foreground px-8 py-4 text-lg font-semibold
+              text-primary-foreground px-6 sm:px-8 py-3 sm:py-4 text-base sm:text-lg font-semibold
               rounded-full shadow-xl
             "
             asChild
@@ -86,7 +86,7 @@ const HeroSection = () => {
             className="
               bg-[#25D366] text-white
               hover:bg-[#1ebe5d]
-              px-8 py-4 text-lg font-semibold rounded-full
+              px-6 sm:px-8 py-3 sm:py-4 text-base sm:text-lg font-semibold rounded-full
               shadow-xl transition-all duration-300
             "
             asChild
@@ -97,14 +97,14 @@ const HeroSection = () => {
           </Button>
         </div>
 
-        <div className="mt-12 flex flex-wrap justify-center gap-4 text-xs sm:text-sm text-muted-foreground">
-          <div className="flex items-center gap-2 bg-black/40 border border-secondary/20 rounded-full px-4 py-2">
+        <div className="mt-10 sm:mt-12 flex flex-wrap justify-center gap-3 sm:gap-4 text-[11px] sm:text-xs text-muted-foreground">
+          <div className="flex items-center gap-1.5 sm:gap-2 bg-black/40 border border-secondary/20 rounded-full px-3 sm:px-4 py-1.5">
             <span>🛡️</span> <span>NATO security cleared drivers</span>
           </div>
-          <div className="flex items-center gap-2 bg-black/40 border border-secondary/20 rounded-full px-4 py-2">
+          <div className="flex items-center gap-1.5 sm:gap-2 bg-black/40 border border-secondary/20 rounded-full px-3 sm:px-4 py-1.5">
             <span>🗺️</span> <span>Door-to-door medzi mestom a základňou</span>
           </div>
-          <div className="flex items-center gap-2 bg-black/40 border border-secondary/20 rounded-full px-4 py-2">
+          <div className="flex items-center gap-1.5 sm:gap-2 bg-black/40 border border-secondary/20 rounded-full px-3 sm:px-4 py-1.5">
             <span>🇪🇸</span> <span>Španielska komunita: odporúčané podniky</span>
           </div>
         </div>

--- a/src/components/OperationsSection.tsx
+++ b/src/components/OperationsSection.tsx
@@ -39,39 +39,39 @@ const pillars = [
 
 const OperationsSection = () => {
   return (
-    <section className="py-20 px-6 bg-gradient-to-b from-black/60 via-background to-black/60">
-      <div className="max-w-6xl mx-auto space-y-16">
-        <div className="text-center space-y-4">
-          <h2 className="text-4xl md:text-5xl font-bold text-gradient-gold">
+    <section className="py-16 sm:py-20 px-4 sm:px-6 bg-gradient-to-b from-black/60 via-background to-black/60">
+      <div className="max-w-6xl mx-auto space-y-12 sm:space-y-16">
+        <div className="text-center space-y-3 sm:space-y-4">
+          <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold text-gradient-gold">
             Operačná pripravenosť TaxiForce
           </h2>
-          <p className="text-lg text-muted-foreground max-w-3xl mx-auto">
+          <p className="text-base sm:text-lg text-muted-foreground max-w-3xl mx-auto">
             Kombinujeme logistiku vojenského štandardu s komfortom civilnej limuzínovej služby. Každé nasadenie plánujeme do detailu.
           </p>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 min-[420px]:grid-cols-2 md:grid-cols-3 gap-4 sm:gap-6">
           {metrics.map((metric) => (
             <div
               key={metric.label}
-              className="text-center bg-primary/10 border border-primary/30 rounded-2xl px-6 py-10 backdrop-blur hover:border-primary/60 transition-all"
+              className="text-center bg-primary/10 border border-primary/30 rounded-2xl px-4 sm:px-6 py-8 sm:py-10 backdrop-blur hover:border-primary/60 transition-all"
             >
-              <p className="text-4xl md:text-5xl font-black text-gradient-military mb-2">{metric.value}</p>
-              <p className="text-sm uppercase tracking-wide text-secondary mb-2">{metric.label}</p>
-              <p className="text-xs text-muted-foreground leading-relaxed">{metric.detail}</p>
+              <p className="text-3xl sm:text-4xl md:text-5xl font-black text-gradient-military mb-1 sm:mb-2">{metric.value}</p>
+              <p className="text-xs sm:text-sm uppercase tracking-wide text-secondary mb-1 sm:mb-2">{metric.label}</p>
+              <p className="text-[11px] sm:text-xs text-muted-foreground leading-relaxed">{metric.detail}</p>
             </div>
           ))}
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+        <div className="grid grid-cols-1 min-[420px]:grid-cols-2 md:grid-cols-3 gap-4 sm:gap-6 md:gap-8">
           {pillars.map((pillar) => (
             <div
               key={pillar.title}
-              className="bg-card/70 border border-secondary/20 rounded-2xl p-6 space-y-4 backdrop-blur hover:border-secondary/50 transition-all"
+              className="bg-card/70 border border-secondary/20 rounded-2xl p-4 sm:p-6 space-y-3 sm:space-y-4 backdrop-blur hover:border-secondary/50 transition-all"
             >
-              <div className="text-4xl">{pillar.icon}</div>
-              <h3 className="text-xl font-semibold text-secondary">{pillar.title}</h3>
-              <p className="text-sm text-muted-foreground leading-relaxed">{pillar.description}</p>
+              <div className="text-3xl sm:text-4xl">{pillar.icon}</div>
+              <h3 className="text-lg sm:text-xl font-semibold text-secondary">{pillar.title}</h3>
+              <p className="text-xs sm:text-sm text-muted-foreground leading-relaxed">{pillar.description}</p>
             </div>
           ))}
         </div>

--- a/src/components/PricingSection.tsx
+++ b/src/components/PricingSection.tsx
@@ -2,54 +2,54 @@ import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 const PricingSection = () => {
-  return <section className="py-20 px-6 bg-gradient-to-b from-muted to-background">
+  return <section className="py-16 sm:py-20 px-4 sm:px-6 bg-gradient-to-b from-muted to-background">
       <div className="max-w-4xl mx-auto text-center">
-        <h2 className="text-4xl md:text-5xl font-bold mb-4 text-gradient-gold">
+        <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-3 sm:mb-4 text-gradient-gold">
           Cenník služieb
         </h2>
-        <p className="text-xl text-muted-foreground mb-12">
+        <p className="text-base sm:text-lg md:text-xl text-muted-foreground mb-8 sm:mb-12">
           Profesionálne ceny pre španielsky vojenský personál
         </p>
 
-        <div className="grid md:grid-cols-2 gap-8 max-w-5xl mx-auto">
+        <div className="grid grid-cols-1 min-[420px]:grid-cols-2 gap-4 sm:gap-6 md:gap-8 max-w-5xl mx-auto">
           <Card className="
-            relative bg-card/50 backdrop-blur-md 
+            relative bg-card/50 backdrop-blur-md
             border-2 border-secondary overflow-hidden
             hover-military
           ">
             <Badge className="
-                absolute -top-2 -right-12 bg-primary text-primary-foreground 
-                px-8 py-1 rotate-45 origin-center font-bold
+                absolute -top-2 -right-12 bg-primary text-primary-foreground
+                px-6 sm:px-8 py-1 rotate-45 origin-center text-xs sm:text-sm font-bold
               ">
               NAJPOPULÁRNEJŠIE
             </Badge>
 
             <CardHeader className="relative">
-              <div className="absolute top-4 left-4 w-16 h-16 bg-gradient-to-br from-secondary to-secondary/70 rounded-full flex items-center justify-center">
-                <span className="text-secondary-foreground font-black text-2xl">€</span>
+              <div className="absolute top-4 left-4 w-14 h-14 sm:w-16 sm:h-16 bg-gradient-to-br from-secondary to-secondary/70 rounded-full flex items-center justify-center">
+                <span className="text-secondary-foreground font-black text-xl sm:text-2xl">€</span>
               </div>
-              
+
               <div className="pt-8">
-                <div className="text-5xl font-black text-secondary mb-2">€35</div>
-                <h3 className="text-2xl font-bold text-foreground">Základňa → Zvolen</h3>
-                <p className="text-muted-foreground">Jednosmerná preprava do Zvolena</p>
+                <div className="text-4xl sm:text-5xl font-black text-secondary mb-1 sm:mb-2">€35</div>
+                <h3 className="text-xl sm:text-2xl font-bold text-foreground">Základňa → Zvolen</h3>
+                <p className="text-sm sm:text-base text-muted-foreground">Jednosmerná preprava do Zvolena</p>
               </div>
             </CardHeader>
 
-            <CardContent className="space-y-4">
+            <CardContent className="space-y-3 sm:space-y-4">
 
-              <div className="text-left space-y-3">
+              <div className="text-left space-y-2.5 sm:space-y-3 text-sm sm:text-base">
                 {["✅ 25% vojenská zľava už aplikovaná", "✅ Priemerný čas príchodu 30 – 40 min podľa dostupnosti", "✅ Garantovaná spiatočná cesta", "✅ Prémiové vozidlo", "✅ Vodič hovoriaci iba po anglicky", "✅ Bezpečnostné overenie NATO", "✅ Platba výlučne v hotovosti"].map((feature, index) => <div key={index} className="flex items-center gap-3">
                     <span className="text-secondary">{feature.split(' ')[0]}</span>
                     <span className="text-foreground">{feature.substring(2)}</span>
                   </div>)}
               </div>
 
-              <div className="pt-6 space-y-4">
+              <div className="pt-4 sm:pt-6 space-y-3 sm:space-y-4">
                 <Button size="lg" className="
-                    w-full bg-gradient-to-r from-primary to-primary-glow 
-                    hover:from-primary-glow hover:to-primary 
-                    text-primary-foreground font-bold py-4 text-lg
+                    w-full bg-gradient-to-r from-primary to-primary-glow
+                    hover:from-primary-glow hover:to-primary
+                    text-primary-foreground font-bold py-3 sm:py-4 text-base sm:text-lg
                     rounded-full shadow-xl hover-military
                   " asChild>
                   <a href="tel:+421919040118">
@@ -58,7 +58,7 @@ const PricingSection = () => {
                 </Button>
 
                 <div className="text-center">
-                  <p className="text-sm text-muted-foreground">
+                  <p className="text-xs sm:text-sm text-muted-foreground">
                     Alebo napíšte na WhatsApp: <span className="text-secondary font-bold">+421919040118</span>
                   </p>
                 </div>
@@ -67,36 +67,36 @@ const PricingSection = () => {
           </Card>
 
           <Card className="
-            relative bg-card/50 backdrop-blur-md 
+            relative bg-card/50 backdrop-blur-md
             border-2 border-primary overflow-hidden
             hover-military
           ">
             <CardHeader className="relative">
-              <div className="absolute top-4 left-4 w-16 h-16 bg-gradient-to-br from-primary to-primary/70 rounded-full flex items-center justify-center">
-                <span className="text-primary-foreground font-black text-2xl">€</span>
+              <div className="absolute top-4 left-4 w-14 h-14 sm:w-16 sm:h-16 bg-gradient-to-br from-primary to-primary/70 rounded-full flex items-center justify-center">
+                <span className="text-primary-foreground font-black text-xl sm:text-2xl">€</span>
               </div>
-              
+
               <div className="pt-8">
-                <div className="text-5xl font-black text-primary mb-2">€60</div>
-                <h3 className="text-2xl font-bold text-foreground">Základňa → B. Bystrica</h3>
-                <p className="text-muted-foreground">Jednosmerná preprava do Banskej Bystrice</p>
+                <div className="text-4xl sm:text-5xl font-black text-primary mb-1 sm:mb-2">€60</div>
+                <h3 className="text-xl sm:text-2xl font-bold text-foreground">Základňa → B. Bystrica</h3>
+                <p className="text-sm sm:text-base text-muted-foreground">Jednosmerná preprava do Banskej Bystrice</p>
               </div>
             </CardHeader>
 
-            <CardContent className="space-y-4">
+            <CardContent className="space-y-3 sm:space-y-4">
 
-              <div className="text-left space-y-3">
+              <div className="text-left space-y-2.5 sm:space-y-3 text-sm sm:text-base">
                 {["✅ 25% vojenská zľava už aplikovaná", "✅ Priemerný čas príchodu 30 – 40 min podľa dostupnosti", "✅ Garantovaná spiatočná cesta", "✅ Prémiové vozidlo", "✅ Vodič hovoriaci iba po anglicky", "✅ Bezpečnostné overenie NATO", "✅ Platba výlučne v hotovosti"].map((feature, index) => <div key={index} className="flex items-center gap-3">
                     <span className="text-secondary">{feature.split(' ')[0]}</span>
                     <span className="text-foreground">{feature.substring(2)}</span>
                   </div>)}
               </div>
 
-              <div className="pt-6 space-y-4">
+              <div className="pt-4 sm:pt-6 space-y-3 sm:space-y-4">
                 <Button size="lg" className="
-                    w-full bg-gradient-to-r from-secondary to-secondary/80 
-                    hover:from-secondary/80 hover:to-secondary 
-                    text-secondary-foreground font-bold py-4 text-lg
+                    w-full bg-gradient-to-r from-secondary to-secondary/80
+                    hover:from-secondary/80 hover:to-secondary
+                    text-secondary-foreground font-bold py-3 sm:py-4 text-base sm:text-lg
                     rounded-full shadow-xl hover-military
                   " asChild>
                   <a href="tel:+421919040118">
@@ -105,7 +105,7 @@ const PricingSection = () => {
                 </Button>
 
                 <div className="text-center">
-                  <p className="text-sm text-muted-foreground">
+                  <p className="text-xs sm:text-sm text-muted-foreground">
                     Alebo napíšte na WhatsApp: <span className="text-secondary font-bold">+421919040118</span>
                   </p>
                 </div>
@@ -114,8 +114,8 @@ const PricingSection = () => {
           </Card>
         </div>
 
-        <div className="mt-12 flex flex-wrap justify-center gap-4">
-          {["🛡️ NATO verifikované", "📱 Okamžité potvrdenie", "⭐ 4.9/5 hodnotenie", "🇪🇸 Španielsky friendly"].map((badge, index) => <div key={index} className="bg-secondary/10 backdrop-blur-md border border-secondary/30 rounded-full px-4 py-2 text-sm font-medium">
+        <div className="mt-8 sm:mt-12 flex flex-wrap justify-center gap-3 sm:gap-4">
+          {["🛡️ NATO verifikované", "📱 Okamžité potvrdenie", "⭐ 4.9/5 hodnotenie", "🇪🇸 Španielsky friendly"].map((badge, index) => <div key={index} className="bg-secondary/10 backdrop-blur-md border border-secondary/30 rounded-full px-3 sm:px-4 py-1.5 sm:py-2 text-xs sm:text-sm font-medium">
               {badge}
             </div>)}
         </div>

--- a/src/components/RouteSection.tsx
+++ b/src/components/RouteSection.tsx
@@ -34,34 +34,34 @@ const steps = [
 
 const RouteSection = () => {
   return (
-    <section className="py-20 px-6 bg-gradient-to-br from-primary/5 via-background to-secondary/5">
-      <div className="max-w-6xl mx-auto space-y-16">
-        <div className="text-center space-y-4">
+    <section className="py-16 sm:py-20 px-4 sm:px-6 bg-gradient-to-br from-primary/5 via-background to-secondary/5">
+      <div className="max-w-6xl mx-auto space-y-12 sm:space-y-16">
+        <div className="text-center space-y-3 sm:space-y-4">
           <Badge className="bg-secondary/20 text-secondary border-secondary/40 uppercase tracking-wide">
             Operačné trasy
           </Badge>
-          <h2 className="text-4xl md:text-5xl font-bold text-gradient-military">
+          <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold text-gradient-military">
             Primárne spojenia pre španielsku jednotku
           </h2>
-          <p className="text-lg text-muted-foreground max-w-3xl mx-auto">
+          <p className="text-base sm:text-lg text-muted-foreground max-w-3xl mx-auto">
             Optimalizované trasy medzi výcvikovým priestorom Lešť, mestom Zvolen a Banskou Bystricou. Zohľadňujeme služby pre voľnočasové aj služobné presuny.
           </p>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+        <div className="grid grid-cols-1 min-[420px]:grid-cols-2 gap-4 sm:gap-6 md:gap-8">
           {routes.map((route) => (
             <Card
               key={route.title}
               className="bg-card/70 backdrop-blur border border-secondary/30 hover:border-secondary/60 transition-all duration-300 hover-military"
             >
-              <CardContent className="p-6 space-y-4">
-                <div className="flex items-center justify-between">
-                  <h3 className="text-2xl font-semibold text-secondary">{route.title}</h3>
-                  <span className="text-sm font-bold text-primary bg-primary/10 px-3 py-1 rounded-full border border-primary/30">
+              <CardContent className="p-5 sm:p-6 space-y-3 sm:space-y-4">
+                <div className="flex items-center justify-between gap-3">
+                  <h3 className="text-xl sm:text-2xl font-semibold text-secondary">{route.title}</h3>
+                  <span className="text-xs sm:text-sm font-bold text-primary bg-primary/10 px-2.5 sm:px-3 py-1 rounded-full border border-primary/30">
                     {route.duration}
                   </span>
                 </div>
-                <ul className="space-y-2 text-sm text-muted-foreground">
+                <ul className="space-y-1.5 sm:space-y-2 text-xs sm:text-sm text-muted-foreground">
                   {route.highlights.map((item) => (
                     <li key={item} className="flex items-start gap-2">
                       <span className="text-secondary">•</span>
@@ -74,15 +74,15 @@ const RouteSection = () => {
           ))}
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 min-[420px]:grid-cols-2 md:grid-cols-3 gap-4 sm:gap-6">
           {steps.map((step) => (
             <div
               key={step.title}
-              className="bg-black/30 border border-secondary/20 rounded-2xl p-6 space-y-3 text-center backdrop-blur hover:border-secondary/50 transition-all"
+              className="bg-black/30 border border-secondary/20 rounded-2xl p-4 sm:p-6 space-y-2.5 sm:space-y-3 text-center backdrop-blur hover:border-secondary/50 transition-all"
             >
-              <h3 className="text-lg font-semibold text-secondary uppercase tracking-wide">{step.title}</h3>
-              <p className="text-sm text-foreground/90 leading-relaxed">{step.detail}</p>
-              <p className="text-xs text-muted-foreground">{step.sub}</p>
+              <h3 className="text-base sm:text-lg font-semibold text-secondary uppercase tracking-wide">{step.title}</h3>
+              <p className="text-xs sm:text-sm text-foreground/90 leading-relaxed">{step.detail}</p>
+              <p className="text-[11px] sm:text-xs text-muted-foreground">{step.sub}</p>
             </div>
           ))}
         </div>

--- a/src/components/SeoContentSection.tsx
+++ b/src/components/SeoContentSection.tsx
@@ -1,32 +1,32 @@
 const SeoContentSection = () => {
   return (
-    <section className="py-20 px-6 bg-background">
-      <article className="max-w-5xl mx-auto space-y-10 text-muted-foreground leading-relaxed">
-        <header className="space-y-4 text-center">
-          <h2 className="text-3xl md:text-4xl font-bold text-gradient-gold">
+    <section className="py-16 sm:py-20 px-4 sm:px-6 bg-background">
+      <article className="max-w-5xl mx-auto space-y-8 sm:space-y-10 text-sm sm:text-base text-muted-foreground leading-relaxed">
+        <header className="space-y-3 sm:space-y-4 text-center">
+          <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold text-gradient-gold">
             Taxi pre španielskych vojakov zo základne Lešť
           </h2>
-          <p className="text-base md:text-lg">
+          <p className="text-sm sm:text-base md:text-lg">
             TaxiForce je špecializovaná prepravná služba so sídlom v Banskobystrickom kraji. Už od roku 2022 zabezpečujeme komfortné a bezpečné spojenie medzi Výcvikovým priestorom Lešť, mestom Zvolen a Banskou Bystricou.
           </p>
         </header>
 
-        <section className="space-y-4">
-          <h3 className="text-2xl font-semibold text-secondary">Profesionalita so zameraním na NATO misie</h3>
+        <section className="space-y-3 sm:space-y-4">
+          <h3 className="text-xl sm:text-2xl font-semibold text-secondary">Profesionalita so zameraním na NATO misie</h3>
           <p>
             Naše vozidlá spĺňajú prísne požiadavky na technický stav a sú vybavené na dlhé presuny aj nočné návraty. Každý vodič je preverovaný, má skúsenosti s medzinárodnými jednotkami a rozumie vojenskej terminológii. Služba je prispôsobená potrebám španielskeho kontingentu a rešpektuje režim utajenia.
           </p>
         </section>
 
-        <section className="space-y-4">
-          <h3 className="text-2xl font-semibold text-secondary">Pokrytie pre Zvolen aj Banskú Bystricu</h3>
+        <section className="space-y-3 sm:space-y-4">
+          <h3 className="text-xl sm:text-2xl font-semibold text-secondary">Pokrytie pre Zvolen aj Banskú Bystricu</h3>
           <p>
             Najčastejšie zabezpečujeme transfery na Zvolenský zámok, námestie vo Zvolene, Europa SC, OC Terminal, reštaurácie v centre Banskej Bystrice a populárne podniky ako Ministry of Fun, Klub 77 či Bar Murgaš. Po dohode vieme zabezpečiť aj výlety do Tatier alebo Budapešti.
           </p>
         </section>
 
-        <section className="space-y-4">
-          <h3 className="text-2xl font-semibold text-secondary">SEO a online viditeľnosť</h3>
+        <section className="space-y-3 sm:space-y-4">
+          <h3 className="text-xl sm:text-2xl font-semibold text-secondary">SEO a online viditeľnosť</h3>
           <p>
             TaxiForce sa zameriava na kľúčové frázy ako <strong>taxi Lešť Zvolen</strong>, <strong>vojenské taxi Slovensko</strong>, <strong>transport Spanish Army Slovakia</strong> a <strong>Lešť Banská Bystrica transfer</strong>. Vďaka optimalizovanému obsahu, recenziám a rýchlemu kontaktu získate spoľahlivého partnera pre logistiku medzinárodných jednotiek na Slovensku.
           </p>

--- a/src/components/TestimonialsSection.tsx
+++ b/src/components/TestimonialsSection.tsx
@@ -34,20 +34,20 @@ const testimonials = [
 
 const TestimonialsSection = () => {
   return (
-    <section className="py-20 px-6 bg-gradient-to-r from-primary/5 via-secondary/5 to-primary/5">
+    <section className="py-16 sm:py-20 px-4 sm:px-6 bg-gradient-to-r from-primary/5 via-secondary/5 to-primary/5">
       <div className="max-w-5xl mx-auto">
-        <div className="text-center mb-16">
-          <h2 className="text-4xl md:text-5xl font-bold mb-4 text-gradient-military">
+        <div className="text-center mb-12 sm:mb-16">
+          <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-3 sm:mb-4 text-gradient-military">
             Čo hovoria naši španielski vojenskí bratia
           </h2>
-          <p className="text-xl text-muted-foreground">
+          <p className="text-base sm:text-lg md:text-xl text-muted-foreground">
             Už viac ako 200 španielskych vojenských pracovníkov dôveruje TaxiForce
           </p>
         </div>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+        <div className="grid grid-cols-1 min-[420px]:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6 md:gap-8">
           {testimonials.map((testimonial, index) => (
-            <Card 
+            <Card
               key={index}
               className="
                 bg-card/80 backdrop-blur-md border-l-4 border-secondary
@@ -56,9 +56,9 @@ const TestimonialsSection = () => {
               "
               style={{ animationDelay: `${index * 0.2}s` }}
             >
-              <CardContent className="p-6">
-                <div className="flex items-start gap-4 mb-4">
-                  <Avatar className="w-16 h-16 border-2 border-secondary">
+              <CardContent className="p-4 sm:p-6">
+                <div className="flex items-start gap-3 sm:gap-4 mb-3 sm:mb-4">
+                  <Avatar className="w-12 h-12 sm:w-16 sm:h-16 border-2 border-secondary">
                     {testimonial.avatar && (
                       <AvatarImage src={testimonial.avatar} alt={testimonial.name} />
                     )}
@@ -66,20 +66,20 @@ const TestimonialsSection = () => {
                       {testimonial.fallback}
                     </AvatarFallback>
                   </Avatar>
-                  
+
                   <div className="flex-1">
-                    <div className="flex mb-2">
+                    <div className="flex mb-1.5 sm:mb-2">
                       {[...Array(testimonial.rating)].map((_, i) => (
-                        <span key={i} className="text-secondary text-xl">⭐</span>
+                        <span key={i} className="text-secondary text-lg sm:text-xl">⭐</span>
                       ))}
                     </div>
-                    
+
                     <h4 className="font-bold text-foreground">{testimonial.name}</h4>
-                    <p className="text-sm text-secondary font-medium">{testimonial.rank}</p>
+                    <p className="text-xs sm:text-sm text-secondary font-medium">{testimonial.rank}</p>
                   </div>
                 </div>
-                
-                <blockquote className="text-muted-foreground italic leading-relaxed">
+
+                <blockquote className="text-sm sm:text-base text-muted-foreground italic leading-relaxed">
                   "{testimonial.text}"
                 </blockquote>
               </CardContent>
@@ -87,8 +87,8 @@ const TestimonialsSection = () => {
           ))}
         </div>
 
-        <div className="text-center mt-12">
-          <div className="inline-flex items-center gap-4 bg-secondary/10 backdrop-blur-md rounded-full px-6 py-3 border border-secondary/30">
+        <div className="text-center mt-10 sm:mt-12">
+          <div className="inline-flex items-center gap-2.5 sm:gap-4 bg-secondary/10 backdrop-blur-md rounded-full px-4 sm:px-6 py-2 sm:py-3 border border-secondary/30 text-xs sm:text-sm">
             <span className="text-secondary font-bold">Hodnotenie: 4.9/5</span>
             <div className="w-px h-4 bg-secondary/30" />
             <span className="text-secondary font-bold">200+ spokojných vojakov</span>


### PR DESCRIPTION
## Summary
- upravil som hero sekciu, tlačidlá a informačné štítky tak, aby mali menšie texty a medzery na malých obrazovkách
- zmenšil som karty, nadpisy a medzery v sekciách s výhodami, trasami, operáciami, cenníkom, blogom, referenciami, FAQ a SEO obsahom pre kompaktnejšie mobilné zobrazenie
- aktualizoval som kontaktnú sekciu a CTA prvky, aby sa na mobiloch zobrazovali vyváženejšie rozloženia a hustejšie mriežky

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d44a4241e88323abbabd0bd42296ca