### PR TITLE
Add English and Spanish language switcher

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,23 +5,26 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import { LanguageProvider } from "./contexts/LanguageContext";
 
 const queryClient = new QueryClient();
 
 const App = () => (
-  <QueryClientProvider client={queryClient}>
-    <TooltipProvider>
-      <Toaster />
-      <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
-    </TooltipProvider>
-  </QueryClientProvider>
+  <LanguageProvider>
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
+        <Toaster />
+        <Sonner />
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Index />} />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </BrowserRouter>
+      </TooltipProvider>
+    </QueryClientProvider>
+  </LanguageProvider>
 );
 
 export default App;

--- a/src/components/BlogSection.tsx
+++ b/src/components/BlogSection.tsx
@@ -1,45 +1,93 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useLanguage } from '@/contexts/LanguageContext';
 
-const posts = [
-  {
-    city: 'Zvolen',
-    title: 'Prvý večer vo Zvolene: zámok, námestie a lokálne bary',
-    excerpt:
-      'Spojte si kultúru s oddychom – navštívte Zvolenský zámok, prejdite sa po Námestí SNP a zakončite večer v baroch Quadra alebo Retro.',
-    highlights: ['Historické centrum', 'Craft koktaily', 'Nočné taxi späť na základňu'],
-    readTime: '4 min čítanie',
+interface BlogPost {
+  city: string;
+  title: string;
+  excerpt: string;
+  highlights: string[];
+  readTime: string;
+}
+
+const translations: Record<'en' | 'es', { heading: string; description: string; posts: BlogPost[] }> = {
+  en: {
+    heading: 'TaxiForce blog',
+    description:
+      'Fresh recommendations for downtime in Zvolen and Banská Bystrica — from restaurants and bars to cultural highlights curated for Spanish troops.',
+    posts: [
+      {
+        city: 'Zvolen',
+        title: 'First night in Zvolen: castle, square and local bars',
+        excerpt:
+          'Combine culture with relaxation — visit Zvolen Castle, stroll along SNP Square and finish the evening in Quadra or Retro.',
+        highlights: ['Historic centre', 'Craft cocktails', 'Night taxi back to base'],
+        readTime: '4 min read',
+      },
+      {
+        city: 'Banská Bystrica',
+        title: 'Evening scene in Banská Bystrica for the Spanish contingent',
+        excerpt:
+          'Europa SC, the main square and lively streets — Ministry of Fun, Klub 77 or Bar Murgaš offer music and space for larger groups.',
+        highlights: ['Nightlife tips', 'Safe transfers', 'Group reservations'],
+        readTime: '5 min read',
+      },
+      {
+        city: 'Gastro picks',
+        title: 'Restaurants with Mediterranean menus and late kitchens',
+        excerpt:
+          'Try tapas at Bistro Chef in Zvolen, Italian classics at Alžbeta and Slovak specialities at Bystrická Klubovňa — all vetted by the community.',
+        highlights: ['Tapas & wine', 'Open after 22:00', 'Table reservations available'],
+        readTime: '3 min read',
+      },
+    ],
   },
-  {
-    city: 'Banská Bystrica',
-    title: 'Banskobystrická večerná scéna pre španielsky kontingent',
-    excerpt:
-      'Europa SC, námestie a ulice plné podnikov – Ministry of Fun, Klub 77 či Bar Murgaš ponúkajú hudbu aj zázemie pre väčšie skupiny.',
-    highlights: ['Nightlife odporúčania', 'Bezpečný presun', 'Rezervácie pre skupiny'],
-    readTime: '5 min čítanie',
+  es: {
+    heading: 'Blog de TaxiForce',
+    description:
+      'Recomendaciones actualizadas para el tiempo libre en Zvolen y Banská Bystrica: restaurantes, bares y planes culturales para las tropas españolas.',
+    posts: [
+      {
+        city: 'Zvolen',
+        title: 'Primera noche en Zvolen: castillo, plaza y bares locales',
+        excerpt:
+          'Une cultura y relax: visita el Castillo de Zvolen, pasea por la Plaza SNP y termina la noche en Quadra o Retro.',
+        highlights: ['Centro histórico', 'Cócteles de autor', 'Taxi nocturno de regreso a la base'],
+        readTime: 'Lectura de 4 min',
+      },
+      {
+        city: 'Banská Bystrica',
+        title: 'Escena nocturna en Banská Bystrica para el contingente español',
+        excerpt:
+          'Europa SC, la plaza principal y calles llenas de locales: Ministry of Fun, Klub 77 o Bar Murgaš ofrecen música y espacio para grupos grandes.',
+        highlights: ['Consejos de nightlife', 'Traslado seguro', 'Reservas para grupos'],
+        readTime: 'Lectura de 5 min',
+      },
+      {
+        city: 'Gastro',
+        title: 'Restaurantes con menú mediterráneo y cocina hasta tarde',
+        excerpt:
+          'Prueba tapas en Bistro Chef de Zvolen, clásicos italianos en Alžbeta y especialidades eslovacas en Bystrická Klubovňa — todo recomendado por la comunidad.',
+        highlights: ['Tapas y vino', 'Abierto después de las 22:00', 'Posibilidad de reservar mesa'],
+        readTime: 'Lectura de 3 min',
+      },
+    ],
   },
-  {
-    city: 'Gastro tipy',
-    title: 'Reštaurácie so stredomorským menu a neskorou kuchyňou',
-    excerpt:
-      'Skúste tapas v Bistro Chef vo Zvolene, talianske klasiky v Alžbete a slovenské špeciality v Bystrickej Klubovni – všetko overené komunitou.',
-    highlights: ['Tapas & víno', 'Otvorené po 22:00', 'Možnosť rezervácie stolov'],
-    readTime: '3 min čítanie',
-  },
-];
+};
 
 const BlogSection = () => {
+  const { language } = useLanguage();
+  const content = translations[language];
+
   return (
     <section className="py-12 sm:py-20 px-4 sm:px-6 bg-gradient-to-b from-muted/40 via-background to-muted/40">
       <div className="max-w-6xl mx-auto space-y-10 sm:space-y-12">
         <div className="text-center space-y-3 sm:space-y-4">
-          <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold text-gradient-gold">Blog TaxiForce</h2>
-          <p className="text-base sm:text-lg text-muted-foreground max-w-3xl mx-auto">
-            Aktuálne tipy pre voľný čas v mestách Zvolen a Banská Bystrica vrátane barov, reštaurácií a kultúrnych zastávok.
-          </p>
+          <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold text-gradient-gold">{content.heading}</h2>
+          <p className="text-base sm:text-lg text-muted-foreground max-w-3xl mx-auto">{content.description}</p>
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-5 sm:gap-6 md:gap-8">
-          {posts.map((post) => (
+          {content.posts.map((post) => (
             <Card
               key={post.title}
               className="bg-card/60 backdrop-blur border border-secondary/20 hover:border-secondary/50 transition-all duration-300"

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -1,10 +1,68 @@
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { useLanguage } from '@/contexts/LanguageContext';
+
+const translations = {
+  en: {
+    heading: 'Contact & bookings',
+    description: [
+      'Reach out for immediate pick-up or schedule your transfer in advance.',
+      'Our professional drivers are on call 24/7.',
+    ],
+    phoneNote: 'Languages: English & Spanish',
+    arrivalInfo: 'Average vehicle arrival time is 30–40 minutes.',
+    paymentInfo: 'Payment accepted in cash (EUR) only.',
+    callButton: 'Call now',
+    whatsappButton: 'WhatsApp booking',
+    availabilityTitle: '📱 Available 24/7 for your transport needs',
+    availabilityBadges: [
+      { icon: '⏰', text: '24/7 on-call' },
+      { icon: '🔒', text: 'Discreet' },
+      { icon: '⚡', text: 'Professional' },
+    ],
+    advantagesTitle: 'Our advantages',
+    advantages: [
+      { icon: '🛡️', text: 'NATO-level security' },
+      { icon: '🚗', text: 'Premium vehicles' },
+      { icon: '👨‍✈️', text: 'Experienced staff' },
+      { icon: '⭐', text: 'Top-rated service' },
+    ],
+    footer: 'TaxiForce s.r.o. • License: SK-TAXI-2024 • Registered with the Ministry of Transport of Slovakia',
+  },
+  es: {
+    heading: 'Contacto y reservas',
+    description: [
+      'Contáctanos para recogida inmediata o reserva anticipada.',
+      'Nuestros conductores profesionales están disponibles 24/7.',
+    ],
+    phoneNote: 'Idiomas: inglés y español',
+    arrivalInfo: 'Tiempo medio de llegada del vehículo: 30–40 minutos.',
+    paymentInfo: 'Pago disponible solo en efectivo (EUR).',
+    callButton: 'Llamar ahora',
+    whatsappButton: 'Reserva por WhatsApp',
+    availabilityTitle: '📱 Disponibles 24/7 para tus traslados',
+    availabilityBadges: [
+      { icon: '⏰', text: 'Guardia 24/7' },
+      { icon: '🔒', text: 'Discreto' },
+      { icon: '⚡', text: 'Profesional' },
+    ],
+    advantagesTitle: 'Nuestras ventajas',
+    advantages: [
+      { icon: '🛡️', text: 'Seguridad a nivel OTAN' },
+      { icon: '🚗', text: 'Vehículos premium' },
+      { icon: '👨‍✈️', text: 'Personal experimentado' },
+      { icon: '⭐', text: 'Servicio con la mejor valoración' },
+    ],
+    footer: 'TaxiForce s.r.o. • Licencia: SK-TAXI-2024 • Registrado en el Ministerio de Transporte de Eslovaquia',
+  },
+} as const;
 
 const ContactSection = () => {
+  const { language } = useLanguage();
+  const content = translations[language];
+
   return (
     <section className="py-12 sm:py-20 px-4 sm:px-6 bg-gradient-to-t from-primary/10 via-background to-secondary/5 relative overflow-hidden">
-      {/* Spanish flag pattern background */}
       <div className="absolute inset-0 opacity-10">
         <div className="absolute top-0 left-0 w-full h-1/3 bg-primary" />
         <div className="absolute top-1/3 left-0 w-full h-1/3 bg-secondary" />
@@ -12,12 +70,11 @@ const ContactSection = () => {
       </div>
 
       <div className="relative z-10 max-w-4xl mx-auto text-center">
-        <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-4 text-gradient-gold">
-          Kontakt a rezervácie
-        </h2>
+        <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-4 text-gradient-gold">{content.heading}</h2>
         <p className="text-base sm:text-lg text-muted-foreground mb-8 sm:mb-12 max-w-2xl mx-auto">
-          Kontaktujte nás pre okamžité vyzdvihnutie alebo rezervujte dopredu.<br />
-          Naši profesionálni vodiči sú k dispozícii 24/7.
+          {content.description[0]}
+          <br />
+          {content.description[1]}
         </p>
 
         <Card className="bg-card/50 backdrop-blur-md border border-secondary/30 p-6 sm:p-8 mb-8">
@@ -26,15 +83,9 @@ const ContactSection = () => {
               <div className="text-3xl sm:text-5xl md:text-6xl font-black text-gradient-gold mb-3 sm:mb-4">
                 📞 +421919040118
               </div>
-              <p className="text-sm sm:text-lg text-muted-foreground">
-                Hovoriť: English
-              </p>
-              <p className="text-xs sm:text-sm text-muted-foreground mt-2">
-                Priemerný čas príchodu vozidla je 30 – 40 minút.
-              </p>
-              <p className="text-xs sm:text-sm font-semibold text-secondary mt-1">
-                Platba je možná len v hotovosti v eurách.
-              </p>
+              <p className="text-sm sm:text-lg text-muted-foreground">{content.phoneNote}</p>
+              <p className="text-xs sm:text-sm text-muted-foreground mt-2">{content.arrivalInfo}</p>
+              <p className="text-xs sm:text-sm font-semibold text-secondary mt-1">{content.paymentInfo}</p>
             </div>
 
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
@@ -48,9 +99,7 @@ const ContactSection = () => {
                 "
                 asChild
               >
-                <a href="tel:+421919040118">
-                  📞 Zavolať teraz
-                </a>
+                <a href="tel:+421919040118">📞 {content.callButton}</a>
               </Button>
 
               <Button
@@ -62,9 +111,7 @@ const ContactSection = () => {
                 "
                 asChild
               >
-                <a href="https://wa.me/421919040118">
-                  💬 WhatsApp rezervácia
-                </a>
+                <a href="https://wa.me/421919040118">💬 {content.whatsappButton}</a>
               </Button>
             </div>
           </CardContent>
@@ -72,28 +119,23 @@ const ContactSection = () => {
 
         <div className="bg-primary/10 backdrop-blur-md border border-primary/30 rounded-xl p-5 sm:p-6 mb-8">
           <p className="text-base sm:text-lg font-semibold text-primary mb-3 sm:mb-4">
-            📱 Dostupné 24/7 pre vaše prepravné potreby
+            {content.availabilityTitle}
           </p>
           <div className="flex flex-wrap justify-center gap-2 sm:gap-4 text-xs sm:text-sm">
-            <span className="text-secondary font-medium">⏰ Dostupné 24/7</span>
-            <span className="hidden sm:inline text-muted-foreground">•</span>
-            <span className="text-secondary font-medium">🔒 Diskrétne</span>
-            <span className="hidden sm:inline text-muted-foreground">•</span>
-            <span className="text-secondary font-medium">⚡ Profesionálne</span>
+            {content.availabilityBadges.map((badge) => (
+              <span key={badge.text} className="text-secondary font-medium">
+                {badge.icon} {badge.text}
+              </span>
+            ))}
           </div>
         </div>
 
         <div className="text-center space-y-3 sm:space-y-4">
-          <h3 className="text-xl sm:text-2xl font-bold text-secondary">Naše výhody</h3>
+          <h3 className="text-xl sm:text-2xl font-bold text-secondary">{content.advantagesTitle}</h3>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-3 sm:gap-4 max-w-2xl mx-auto">
-            {[
-              { icon: "🛡️", text: "NATO bezpečnosť" },
-              { icon: "🚗", text: "Prémiové vozidlá" },
-              { icon: "👨‍✈️", text: "Vojenský personál" },
-              { icon: "⭐", text: "Top hodnotenie" }
-            ].map((item, index) => (
+            {content.advantages.map((item) => (
               <div
-                key={index}
+                key={item.text}
                 className="text-center p-3 sm:p-4 bg-secondary/5 rounded-lg border border-secondary/20"
               >
                 <div className="text-xl sm:text-2xl mb-1 sm:mb-2">{item.icon}</div>
@@ -104,9 +146,7 @@ const ContactSection = () => {
         </div>
 
         <div className="mt-10 sm:mt-12 text-center">
-          <p className="text-xs sm:text-sm text-muted-foreground">
-            TaxiForce s.r.o. • Licencia: SK-TAXI-2024 • Registrované na Ministerstve dopravy SR
-          </p>
+          <p className="text-xs sm:text-sm text-muted-foreground">{content.footer}</p>
         </div>
       </div>
     </section>

--- a/src/components/FaqSection.tsx
+++ b/src/components/FaqSection.tsx
@@ -1,45 +1,83 @@
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
+import { useLanguage } from '@/contexts/LanguageContext';
 
-const faqs = [
-  {
-    question: 'Ako rýchlo viete prísť na základňu Lešť?',
-    answer:
-      'Štandardne vychádzame do 8 minút od potvrdenia objednávky. Počas veľkých cvičení máme pripravené posilové vozidlá.',
-    translation: '¿Cuánto tardan en llegar a la base de Lešť? — Salimos en un máximo de 8 minutos tras la confirmación, incluso durante maniobras.',
+const translations = {
+  en: {
+    heading: 'Frequently asked questions',
+    description:
+      'Clear answers in English and Spanish for the Spanish contingent operating from Lešť. Here are the most common questions we receive.',
+    faqs: [
+      {
+        question: 'How fast can you reach Lešť base?',
+        answer: 'We usually depart within 8 minutes after confirmation. During large exercises we activate additional vehicles.',
+        note: '¿Cuánto tardan en llegar a la base de Lešť? — Salimos en un máximo de 8 minutos tras la confirmación, incluso durante maniobras.',
+      },
+      {
+        question: 'Can we pay by card or invoice?',
+        answer:
+          'Yes, we accept military cards, cash and unit invoicing. Monthly ride summaries are available on request.',
+        note: '¿Se puede pagar con tarjeta o por factura? — Aceptamos tarjetas, efectivo y facturación mensual para la unidad.',
+      },
+      {
+        question: 'What if the unit schedule changes?',
+        answer:
+          'We stay in touch with logistics officers and adjust transfers without extra fees. Drivers remain on standby in town.',
+        note: '¿Qué pasa si cambia el horario? — Coordinamos con logística y ajustamos la vuelta sin coste adicional.',
+      },
+      {
+        question: 'How much is waiting time during dinner?',
+        answer: 'Thirty minutes are included. Each additional hour is €15, with the driver waiting close to the venue.',
+        note: '¿Cuál es el precio por la espera? — 30 minutos incluidos; cada hora adicional 15 €, con el chofer cerca del restaurante.',
+      },
+    ],
   },
-  {
-    question: 'Je možné zaplatiť kartou alebo faktúrou?',
-    answer:
-      'Áno, akceptujeme vojenské karty, hotovosť aj fakturáciu pre jednotku. Na požiadanie pripravíme mesačný prehľad jázd.',
-    translation: '¿Se puede pagar con tarjeta o por factura? — Aceptamos tarjetas, efectivo y facturación mensual para la unidad.',
+  es: {
+    heading: 'Preguntas frecuentes',
+    description:
+      'Respuestas claras en inglés y español para el contingente destacado en Lešť. Estas son las consultas que recibimos con más frecuencia.',
+    faqs: [
+      {
+        question: '¿En cuánto tiempo pueden llegar a la base de Lešť?',
+        answer:
+          'Salimos normalmente en un máximo de 8 minutos tras confirmar la reserva. En grandes maniobras activamos vehículos de refuerzo.',
+        note: 'How fast can you reach Lešť base? — We depart within 8 minutes after confirmation, even during exercises.',
+      },
+      {
+        question: '¿Se puede pagar con tarjeta o por factura?',
+        answer:
+          'Sí, aceptamos tarjetas militares, efectivo y facturación para la unidad. Podemos preparar resúmenes mensuales.',
+        note: 'Can we pay by card or invoice? — We accept cards, cash and monthly invoicing for the unit.',
+      },
+      {
+        question: '¿Qué ocurre si cambia el horario de la unidad?',
+        answer:
+          'Estamos en contacto con logística y reajustamos el traslado sin cargos adicionales. El conductor permanece en la ciudad en espera.',
+        note: 'What if the unit schedule changes? — We coordinate with logistics and reschedule without extra fees.',
+      },
+      {
+        question: '¿Cuál es el precio por el tiempo de espera durante la cena?',
+        answer:
+          'Incluimos 30 minutos. Cada hora adicional son 15 €, con el chofer esperando cerca del lugar.',
+        note: 'How much is waiting time during dinner? — 30 minutes included; each extra hour is €15 with the driver nearby.',
+      },
+    ],
   },
-  {
-    question: 'Čo ak sa zmení program jednotky?',
-    answer:
-      'Sme v kontakte s dôstojníkmi pre logistiku. Transfer presunieme bez poplatku, vodič zostáva v pohotovosti v meste.',
-    translation: '¿Qué pasa si cambia el horario? — Coordinamos con logística y ajustamos la vuelta sin coste adicional.',
-  },
-  {
-    question: 'Koľko stojí čakacia doba počas večere?',
-    answer:
-      'V cene je zahrnutých 30 minút. Každá ďalšia začatá hodina je 15 €. Čakáme priamo v blízkosti podniku.',
-    translation: '¿Cuál es el precio por la espera? — 30 minutos incluidos; cada hora adicional 15 €, con el chofer cerca del restaurante.',
-  },
-];
+} as const;
 
 const FaqSection = () => {
+  const { language } = useLanguage();
+  const content = translations[language];
+
   return (
     <section className="py-12 sm:py-20 px-4 sm:px-6 bg-gradient-to-br from-secondary/5 via-background to-primary/5">
       <div className="max-w-4xl mx-auto">
         <div className="text-center mb-8 sm:mb-12 space-y-3">
-          <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold text-gradient-military">Najčastejšie otázky</h2>
-          <p className="text-base sm:text-lg text-muted-foreground">
-            Transparentne komunikujeme v slovenčine, angličtine aj španielčine. Tu sú najčastejšie otázky španielskej jednotky.
-          </p>
+          <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold text-gradient-military">{content.heading}</h2>
+          <p className="text-base sm:text-lg text-muted-foreground">{content.description}</p>
         </div>
 
         <Accordion type="single" collapsible className="space-y-3 sm:space-y-4">
-          {faqs.map((faq, index) => (
+          {content.faqs.map((faq, index) => (
             <AccordionItem
               key={faq.question}
               value={`faq-${index}`}
@@ -50,7 +88,7 @@ const FaqSection = () => {
               </AccordionTrigger>
               <AccordionContent className="px-4 sm:px-6 pb-5 sm:pb-6 space-y-2 sm:space-y-3">
                 <p className="text-sm text-muted-foreground leading-relaxed sm:text-base">{faq.answer}</p>
-                <p className="text-[11px] sm:text-sm text-secondary/80 italic">{faq.translation}</p>
+                <p className="text-[11px] sm:text-sm text-secondary/80 italic">{faq.note}</p>
               </AccordionContent>
             </AccordionItem>
           ))}

--- a/src/components/FeaturesSection.tsx
+++ b/src/components/FeaturesSection.tsx
@@ -3,73 +3,137 @@ import militaryBadge from '@/assets/military-badge.jpg';
 import restaurantImage from '@/assets/restaurant-bb.jpg';
 import taxiImage from '@/assets/taxi-military.jpg';
 import cityImage from '@/assets/banska-bystrica-night.jpg';
+import { useLanguage } from '@/contexts/LanguageContext';
 
-const features = [
-  {
-    icon: '🚐',
-    title: 'Priame spojenie Lešť → Zvolen / Banská Bystrica',
-    description:
-      'Monitorujeme pohyb jednotiek a koordinujeme vyzdvihnutia priamo pri bráne základne. Vozidlo štandardne dorazí do 30 – 40 minút.',
-    image: taxiImage,
-    badge: 'Non-stop dispečing',
+const translations = {
+  en: {
+    heading: 'Why choose TaxiForce?',
+    description: 'Specialised transfer unit dedicated to Spanish military personnel deployed at Lešť base.',
+    features: [
+      {
+        icon: '🚐',
+        title: 'Direct connection Lešť → Zvolen / Banská Bystrica',
+        description:
+          'We monitor troop movements and coordinate pick-ups at the base gate. Vehicles usually arrive within 30–40 minutes.',
+        image: taxiImage,
+        badge: '24/7 dispatch',
+      },
+      {
+        icon: '🛡️',
+        title: 'NATO security standards',
+        description:
+          'All drivers are vetted, bound by confidentiality agreements and trained for both duty and leisure transfers.',
+        image: militaryBadge,
+        badge: 'Security cleared',
+      },
+      {
+        icon: '🍻',
+        title: 'Local tips for the Spanish unit',
+        description:
+          'From tapas bars to nightclubs, we curate a trusted list of safe partner venues in both cities.',
+        image: restaurantImage,
+        badge: 'Insider tips',
+      },
+      {
+        icon: '🌙',
+        title: 'Operations 24/7 including late returns',
+        description:
+          'Coverage for evening outings and early training deployments. Waiting time is tailored individually to your plan.',
+        image: cityImage,
+        badge: 'Night ready',
+      },
+      {
+        icon: '💶',
+        title: 'Cash payments only',
+        description:
+          'Simple and transparent – pay in euros upon pick-up, card payments are not available.',
+        image: null,
+        badge: 'Payment info',
+      },
+      {
+        icon: '🇪🇸',
+        title: 'English and Spanish communication',
+        description:
+          'Dispatch understands military terminology; drivers are ready to handle English and essential Spanish phrases.',
+        image: null,
+        badge: 'Language support',
+      },
+    ],
   },
-  {
-    icon: '🛡️',
-    title: 'Bezpečnostné štandardy NATO',
-    description:
-      'Všetci vodiči sú preverení, zmluvne viazaní mlčanlivosťou a poznajú protokoly pre služobné aj voľnočasové presuny.',
-    image: militaryBadge,
-    badge: 'Security cleared',
+  es: {
+    heading: '¿Por qué elegir TaxiForce?',
+    description: 'Unidad de traslados especializada para el personal militar español destacado en la base de Lešť.',
+    features: [
+      {
+        icon: '🚐',
+        title: 'Conexión directa Lešť → Zvolen / Banská Bystrica',
+        description:
+          'Supervisamos los movimientos de la unidad y coordinamos recogidas en la puerta de la base. El vehículo llega en 30–40 minutos.',
+        image: taxiImage,
+        badge: 'Central 24/7',
+      },
+      {
+        icon: '🛡️',
+        title: 'Estándares de seguridad OTAN',
+        description:
+          'Todos los conductores están verificados, sujetos a confidencialidad y formados para traslados de servicio y ocio.',
+        image: militaryBadge,
+        badge: 'Security cleared',
+      },
+      {
+        icon: '🍻',
+        title: 'Recomendaciones locales para la unidad',
+        description:
+          'Desde bares de tapas hasta discotecas: lista de socios segura y de confianza en ambas ciudades.',
+        image: restaurantImage,
+        badge: 'Insider tips',
+      },
+      {
+        icon: '🌙',
+        title: 'Operaciones 24/7 con regresos tardíos',
+        description:
+          'Cobertura para salidas nocturnas y despliegues tempranos. El tiempo de espera se ajusta a vuestro plan.',
+        image: cityImage,
+        badge: 'Night ready',
+      },
+      {
+        icon: '💶',
+        title: 'Pagos solo en efectivo',
+        description:
+          'Proceso sencillo y transparente: pagas en euros al subir, no disponible pago con tarjeta.',
+        image: null,
+        badge: 'Payment info',
+      },
+      {
+        icon: '🇪🇸',
+        title: 'Comunicación en inglés y español',
+        description:
+          'La central conoce la terminología militar y los conductores manejan inglés y las frases esenciales en español.',
+        image: null,
+        badge: 'Language support',
+      },
+    ],
   },
-  {
-    icon: '🍻',
-    title: 'Lokálne odporúčania pre španielsku jednotku',
-    description:
-      'Od tapas barov po nočné kluby – pripravili sme partnerský zoznam bezpečných a overených miest v oboch mestách.',
-    image: restaurantImage,
-    badge: 'Insider tips',
-  },
-  {
-    icon: '🌙',
-    title: 'Operácie 24/7 vrátane neskorých návratov',
-    description:
-      'Služba pokrýva nočné vychádzky aj skoré ranné presuny na cvičenia. Čakanie sa dohodne individuálne podľa tarify.',
-    image: cityImage,
-    badge: 'Night ready',
-  },
-  {
-    icon: '💶',
-    title: 'Platba výlučne v hotovosti',
-    description:
-      'Fakturácia je jednoduchá a transparentná – platíte pri nástupe v eurách, bez možnosti kartovej platby.',
-    image: null,
-    badge: 'Payment info',
-  },
-  {
-    icon: '🇪🇸',
-    title: 'Komunikácia v angličtine + základná španielčina',
-    description:
-      'Dispečing rozumie vojenským termínom, vodiči sú pripravení komunikovať v angličtine a najčastejších frázach po španielsky.',
-    image: null,
-    badge: 'Language support',
-  },
-];
+} as const;
 
 const FeaturesSection = () => {
+  const { language } = useLanguage();
+  const content = translations[language];
+
   return (
     <section className="py-12 sm:py-20 px-4 sm:px-6 bg-gradient-to-b from-background to-muted">
       <div className="max-w-7xl mx-auto">
         <div className="text-center mb-10 sm:mb-16">
           <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-4 text-gradient-gold">
-            Prečo zvoliť TaxiForce?
+            {content.heading}
           </h2>
           <p className="text-base sm:text-lg md:text-xl text-muted-foreground max-w-3xl mx-auto">
-            Špecializovaná prepravná jednotka pre španielsky vojenský personál pôsobiaci na základni Lešť
+            {content.description}
           </p>
         </div>
 
         <div className="grid grid-cols-1 min-[360px]:grid-cols-2 md:grid-cols-3 gap-4 sm:gap-6 lg:gap-8">
-          {features.map((feature, index) => (
+          {content.features.map((feature, index) => (
             <Card
               key={feature.title}
               className="

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,7 +1,78 @@
 import { Button } from '@/components/ui/button';
 import heroImage from '@/assets/hero-military.jpg';
+import { useLanguage } from '@/contexts/LanguageContext';
+
+const translations = {
+  en: {
+    routeBadge: '🇪🇸 Base Training Area Lešť → Zvolen / Banská Bystrica',
+    serviceBadge: 'NATO vetted • Discreet 24/7',
+    heading: 'TaxiForce Military Transfers',
+    description:
+      'Premium transport dedicated to Spanish military personnel stationed in Slovakia. Fast transfers from Lešť base to Zvolen and Banská Bystrica with safe returns back to duty.',
+    descriptionHighlight: 'Service available in English and Spanish on request.',
+    stats: [
+      {
+        title: 'Average arrival time',
+        value: '30 – 40 minutes',
+        note: '24/7 dispatch confirms availability in real time',
+      },
+      {
+        title: 'Vehicle capacity',
+        value: 'Up to 4 passengers',
+        note: 'Luxury SUV or business sedan fleet',
+      },
+      {
+        title: 'Payment method',
+        value: 'Cash only',
+        note: 'Please prepare the fare before departure',
+      },
+    ],
+    callCta: 'Call TaxiForce',
+    whatsappCta: 'WhatsApp booking',
+    badges: [
+      { icon: '🛡️', text: 'NATO security-cleared drivers' },
+      { icon: '🗺️', text: 'Door-to-door between base and city' },
+      { icon: '🇪🇸', text: 'Spanish community recommendations' },
+    ],
+  },
+  es: {
+    routeBadge: '🇪🇸 Base de adiestramiento Lešť → Zvolen / Banská Bystrica',
+    serviceBadge: 'Aprobado por la OTAN • Discreto 24/7',
+    heading: 'TaxiForce Traslados Militares',
+    description:
+      'Transporte premium dedicado al personal militar español destacado en Eslovaquia. Traslados rápidos desde la base de Lešť a Zvolen y Banská Bystrica con retornos seguros al servicio.',
+    descriptionHighlight: 'Servicio disponible en inglés y español bajo solicitud.',
+    stats: [
+      {
+        title: 'Tiempo medio de llegada',
+        value: '30 – 40 minutos',
+        note: 'Central 24/7 confirma la disponibilidad en tiempo real',
+      },
+      {
+        title: 'Capacidad del vehículo',
+        value: 'Hasta 4 pasajeros',
+        note: 'Flota de SUV de lujo o sedanes ejecutivos',
+      },
+      {
+        title: 'Método de pago',
+        value: 'Solo efectivo',
+        note: 'Prepare el importe antes de la salida',
+      },
+    ],
+    callCta: 'Llamar a TaxiForce',
+    whatsappCta: 'Reserva por WhatsApp',
+    badges: [
+      { icon: '🛡️', text: 'Conductores acreditados por la OTAN' },
+      { icon: '🗺️', text: 'Puerta a puerta entre base y ciudad' },
+      { icon: '🇪🇸', text: 'Recomendaciones para la comunidad española' },
+    ],
+  },
+} as const;
 
 const HeroSection = () => {
+  const { language } = useLanguage();
+  const content = translations[language];
+
   return (
     <section
       className="relative min-h-[85vh] sm:min-h-screen flex items-center justify-center text-center bg-hero-pattern"
@@ -20,39 +91,25 @@ const HeroSection = () => {
       <div className="relative z-10 max-w-5xl px-4 py-16 sm:px-6 sm:py-20">
         <div className="flex flex-wrap items-center justify-center gap-3 mb-8">
           <span className="bg-gradient-to-r from-primary to-secondary px-3 py-2 rounded-full text-[11px] sm:text-sm font-bold uppercase tracking-wide shadow-lg">
-            🇪🇸 Base Training Area Lešť → Zvolen / Banská Bystrica
+            {content.routeBadge}
           </span>
           <span className="bg-secondary/10 border border-secondary/40 text-secondary px-3 py-1 rounded-full text-[11px] sm:text-sm font-semibold backdrop-blur">
-            Overené NATO • Diskrétne 24/7
+            {content.serviceBadge}
           </span>
         </div>
 
         <h1 className="text-3xl sm:text-5xl md:text-6xl xl:text-7xl font-black mb-5 sm:mb-6 text-gradient-military drop-shadow-2xl leading-tight">
-          TaxiForce Military Transfers
+          {content.heading}
         </h1>
 
         <p className="text-base sm:text-lg md:text-2xl mb-8 sm:mb-10 text-foreground/90 max-w-3xl mx-auto leading-relaxed">
-          Prémiová preprava pre španielsky vojenský personál na Slovensku. Rýchle transfery zo základne Lešť do Zvolena a Banskej Bystrice, bezpečné návraty späť.
+          {content.description}
           <br className="hidden md:block" />
-          <span className="text-secondary font-semibold">Servicio disponible también en español bajo požiadavke.</span>
+          <span className="text-secondary font-semibold">{content.descriptionHighlight}</span>
         </p>
 
         <div className="grid grid-cols-1 min-[380px]:grid-cols-2 sm:grid-cols-3 gap-3 sm:gap-4 mb-8 sm:mb-10 text-left text-xs sm:text-sm">
-          {[{
-            title: 'Priemerný čas príchodu',
-            value: '30 – 40 minút',
-            note: 'Non-stop dispečing potvrdzuje dostupnosť v reálnom čase',
-          },
-          {
-            title: 'Kapacita jedného vozidla',
-            value: '4 pasažieri',
-            note: 'Luxusné SUV alebo business sedan',
-          },
-          {
-            title: 'Platba',
-            value: 'Len v hotovosti',
-            note: 'Prosíme pripraviť si sumu pred odjazdom',
-          }].map((item, index) => (
+          {content.stats.map((item, index) => (
             <div
               key={item.title}
               className="bg-black/30 border border-secondary/20 rounded-xl p-3 sm:p-4 backdrop-blur hover:border-secondary/40 transition-all duration-300"
@@ -77,7 +134,7 @@ const HeroSection = () => {
             asChild
           >
             <a href="tel:+421919040118">
-              📞 Zavolať TaxiForce
+              📞 {content.callCta}
             </a>
           </Button>
 
@@ -92,21 +149,20 @@ const HeroSection = () => {
             asChild
           >
             <a href="https://wa.me/421919040118">
-              💬 WhatsApp rezervácia
+              💬 {content.whatsappCta}
             </a>
           </Button>
         </div>
 
         <div className="mt-10 sm:mt-12 flex flex-wrap justify-center gap-3 sm:gap-4 text-[11px] sm:text-xs md:text-sm text-muted-foreground">
-          <div className="flex items-center gap-2 bg-black/40 border border-secondary/20 rounded-full px-3 py-2">
-            <span>🛡️</span> <span>NATO security cleared drivers</span>
-          </div>
-          <div className="flex items-center gap-2 bg-black/40 border border-secondary/20 rounded-full px-3 py-2">
-            <span>🗺️</span> <span>Door-to-door medzi mestom a základňou</span>
-          </div>
-          <div className="flex items-center gap-2 bg-black/40 border border-secondary/20 rounded-full px-3 py-2">
-            <span>🇪🇸</span> <span>Španielska komunita: odporúčané podniky</span>
-          </div>
+          {content.badges.map((badge) => (
+            <div
+              key={badge.text}
+              className="flex items-center gap-2 bg-black/40 border border-secondary/20 rounded-full px-3 py-2"
+            >
+              <span>{badge.icon}</span> <span>{badge.text}</span>
+            </div>
+          ))}
         </div>
       </div>
     </section>

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -1,0 +1,35 @@
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { useLanguage, type Language } from '@/contexts/LanguageContext';
+
+const languages: { label: string; value: Language }[] = [
+  { label: 'English', value: 'en' },
+  { label: 'Español', value: 'es' },
+];
+
+const LanguageSwitcher = () => {
+  const { language, setLanguage } = useLanguage();
+
+  return (
+    <div className="fixed top-4 right-4 z-50 flex items-center gap-2 rounded-full bg-black/70 px-2 py-2 backdrop-blur">
+      {languages.map(({ label, value }) => (
+        <Button
+          key={value}
+          variant="ghost"
+          size="sm"
+          className={cn(
+            'rounded-full border border-transparent text-xs font-semibold uppercase tracking-wide text-white transition-all',
+            language === value
+              ? 'bg-secondary text-secondary-foreground shadow-lg'
+              : 'hover:bg-white/10 hover:text-white'
+          )}
+          onClick={() => setLanguage(value)}
+        >
+          {label}
+        </Button>
+      ))}
+    </div>
+  );
+};
+
+export default LanguageSwitcher;

--- a/src/components/OperationsSection.tsx
+++ b/src/components/OperationsSection.tsx
@@ -1,57 +1,110 @@
-const metrics = [
-  {
-    value: '4.9/5',
-    label: 'Hodnotenie španielskeho kontingentu',
-    detail: 'Z reálnych feedback formulárov po nočných výjazdoch',
-  },
-  {
-    value: '120+',
-    label: 'mesačných transferov',
-    detail: 'Stála posádka vodičov so striedaním počas cvičení',
-  },
-  {
-    value: '0 incidentov',
-    label: 'za 24 mesiacov služby',
-    detail: 'Dodržiavame bezpečnostné protokoly NATO aj miestne zákony',
-  },
-];
+import { useLanguage } from '@/contexts/LanguageContext';
 
-const pillars = [
-  {
-    title: 'Vojenská presnosť',
+const translations = {
+  en: {
+    heading: 'TaxiForce operational readiness',
     description:
-      'Pracujeme podľa operačných plánov. Každý transfer má pridelené číslo misie a potvrdený čas návratu.',
-    icon: '⏱️',
+      'We combine military-grade logistics with the comfort of a private chauffeur service. Every deployment is planned in detail.',
+    metrics: [
+      {
+        value: '4.9/5',
+        label: 'Spanish contingent rating',
+        detail: 'Based on real feedback reports after night deployments',
+      },
+      {
+        value: '120+',
+        label: 'monthly transfers',
+        detail: 'Dedicated driver roster with reinforcements during exercises',
+      },
+      {
+        value: '0 incidents',
+        label: 'in 24 months of service',
+        detail: 'Strict compliance with NATO security protocols and local law',
+      },
+    ],
+    pillars: [
+      {
+        title: 'Military precision',
+        description:
+          'We operate according to mission plans. Each transfer receives a mission number and confirmed return time.',
+        icon: '⏱️',
+      },
+      {
+        title: 'Discretion & security',
+        description:
+          'Non-disclosure agreements, anonymous payments and unmarked vehicles. Drivers are experienced with escorts and VIP transfers.',
+        icon: '🕶️',
+      },
+      {
+        title: 'Community support',
+        description:
+          'Local partnerships ensure Spanish troops have access to trusted services during downtime.',
+        icon: '🤝',
+      },
+    ],
   },
-  {
-    title: 'Diskrétnosť a bezpečnosť',
+  es: {
+    heading: 'Preparación operativa de TaxiForce',
     description:
-      'Zmluvná mlčanlivosť, anonymné platby a neoznačené vozidlá. Vodiči sú skúsení s eskortami aj VIP transfermi.',
-    icon: '🕶️',
+      'Combinamos logística de nivel militar con el confort de un servicio de chofer privado. Cada despliegue se planifica al detalle.',
+    metrics: [
+      {
+        value: '4.9/5',
+        label: 'Valoración del contingente español',
+        detail: 'Basada en informes reales tras salidas nocturnas',
+      },
+      {
+        value: '120+',
+        label: 'traslados mensuales',
+        detail: 'Equipo fijo de conductores con refuerzos durante ejercicios',
+      },
+      {
+        value: '0 incidentes',
+        label: 'en 24 meses de servicio',
+        detail: 'Cumplimos los protocolos de seguridad OTAN y la normativa local',
+      },
+    ],
+    pillars: [
+      {
+        title: 'Precisión militar',
+        description:
+          'Trabajamos siguiendo planes operativos. Cada traslado recibe número de misión y hora de regreso confirmada.',
+        icon: '⏱️',
+      },
+      {
+        title: 'Discreción y seguridad',
+        description:
+          'Acuerdos de confidencialidad, pagos anónimos y vehículos sin distintivos. Conductores expertos en escoltas y traslados VIP.',
+        icon: '🕶️',
+      },
+      {
+        title: 'Apoyo comunitario',
+        description:
+          'Colaboramos con socios locales para que la tropa española acceda a servicios fiables en su tiempo libre.',
+        icon: '🤝',
+      },
+    ],
   },
-  {
-    title: 'Komunitná podpora',
-    description:
-      'Spolupracujeme s miestnymi partnermi, aby španielske jednotky mali dostupné kvalitné služby počas voľna.',
-    icon: '🤝',
-  },
-];
+} as const;
 
 const OperationsSection = () => {
+  const { language } = useLanguage();
+  const content = translations[language];
+
   return (
     <section className="py-12 sm:py-20 px-4 sm:px-6 bg-gradient-to-b from-black/60 via-background to-black/60">
       <div className="max-w-6xl mx-auto space-y-10 sm:space-y-16">
         <div className="text-center space-y-3 sm:space-y-4">
           <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold text-gradient-gold">
-            Operačná pripravenosť TaxiForce
+            {content.heading}
           </h2>
           <p className="text-base sm:text-lg text-muted-foreground max-w-3xl mx-auto">
-            Kombinujeme logistiku vojenského štandardu s komfortom civilnej limuzínovej služby. Každé nasadenie plánujeme do detailu.
+            {content.description}
           </p>
         </div>
 
         <div className="grid grid-cols-1 min-[380px]:grid-cols-2 sm:grid-cols-3 gap-4 sm:gap-6">
-          {metrics.map((metric) => (
+          {content.metrics.map((metric) => (
             <div
               key={metric.label}
               className="text-center bg-primary/10 border border-primary/30 rounded-2xl px-4 py-6 sm:px-5 sm:py-8 md:px-6 md:py-10 backdrop-blur hover:border-primary/60 transition-all"
@@ -64,7 +117,7 @@ const OperationsSection = () => {
         </div>
 
         <div className="grid grid-cols-1 min-[500px]:grid-cols-2 md:grid-cols-3 gap-4 sm:gap-6 md:gap-8">
-          {pillars.map((pillar) => (
+          {content.pillars.map((pillar) => (
             <div
               key={pillar.title}
               className="bg-card/70 border border-secondary/20 rounded-2xl p-4 sm:p-5 md:p-6 space-y-3 sm:space-y-4 backdrop-blur hover:border-secondary/50 transition-all"

--- a/src/components/PricingSection.tsx
+++ b/src/components/PricingSection.tsx
@@ -1,126 +1,224 @@
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { useLanguage } from '@/contexts/LanguageContext';
+
+type PricingCard = {
+  highlight?: string;
+  highlightClass?: string;
+  borderClass: string;
+  circleClass: string;
+  priceClass: string;
+  buttonClass: string;
+  price: string;
+  title: string;
+  subtitle: string;
+  features: { icon: string; text: string }[];
+  button: string;
+  whatsapp: string;
+};
+
+const translations: Record<
+  'en' | 'es',
+  {
+    heading: string;
+    description: string;
+    cards: PricingCard[];
+    badges: string[];
+  }
+> = {
+  en: {
+    heading: 'Service pricing',
+    description: 'Professional rates dedicated to Spanish military personnel.',
+    cards: [
+      {
+        highlight: 'Most popular',
+        highlightClass: 'bg-primary text-primary-foreground',
+        borderClass: 'border-secondary',
+        circleClass: 'bg-gradient-to-br from-secondary to-secondary/70',
+        priceClass: 'text-secondary',
+        buttonClass:
+          'from-primary to-primary-glow hover:from-primary-glow hover:to-primary text-primary-foreground',
+        price: '€35',
+        title: 'Base → Zvolen',
+        subtitle: 'One-way transfer to Zvolen',
+        features: [
+          { icon: '✅', text: '25% military discount already applied' },
+          { icon: '✅', text: 'Average arrival time 30–40 min depending on availability' },
+          { icon: '✅', text: 'Return trip guaranteed on request' },
+          { icon: '✅', text: 'Premium SUV or executive sedan' },
+          { icon: '✅', text: 'Driver fluent in English' },
+          { icon: '✅', text: 'NATO security clearance' },
+          { icon: '✅', text: 'Cash payments in euros only' },
+        ],
+        button: 'Book a ride',
+        whatsapp: 'Or message us on WhatsApp: ',
+      },
+      {
+        borderClass: 'border-primary',
+        circleClass: 'bg-gradient-to-br from-primary to-primary/70',
+        priceClass: 'text-primary',
+        buttonClass:
+          'from-secondary to-secondary/80 hover:from-secondary/80 hover:to-secondary text-secondary-foreground',
+        price: '€60',
+        title: 'Base → Banská Bystrica',
+        subtitle: 'One-way transfer to Banská Bystrica',
+        features: [
+          { icon: '✅', text: '25% military discount already applied' },
+          { icon: '✅', text: 'Average arrival time 30–40 min depending on availability' },
+          { icon: '✅', text: 'Return trip guaranteed on request' },
+          { icon: '✅', text: 'Premium SUV or executive sedan' },
+          { icon: '✅', text: 'Driver fluent in English' },
+          { icon: '✅', text: 'NATO security clearance' },
+          { icon: '✅', text: 'Cash payments in euros only' },
+        ],
+        button: 'Book a ride',
+        whatsapp: 'Or message us on WhatsApp: ',
+      },
+    ],
+    badges: ['🛡️ NATO verified', '📱 Instant confirmation', '⭐ 4.9/5 rating', '🇪🇸 Spanish friendly'],
+  },
+  es: {
+    heading: 'Tarifas del servicio',
+    description: 'Precios profesionales para el personal militar español.',
+    cards: [
+      {
+        highlight: 'Más solicitado',
+        highlightClass: 'bg-primary text-primary-foreground',
+        borderClass: 'border-secondary',
+        circleClass: 'bg-gradient-to-br from-secondary to-secondary/70',
+        priceClass: 'text-secondary',
+        buttonClass:
+          'from-primary to-primary-glow hover:from-primary-glow hover:to-primary text-primary-foreground',
+        price: '€35',
+        title: 'Base → Zvolen',
+        subtitle: 'Traslado solo ida a Zvolen',
+        features: [
+          { icon: '✅', text: '25% de descuento militar ya aplicado' },
+          { icon: '✅', text: 'Tiempo medio de llegada 30–40 min según disponibilidad' },
+          { icon: '✅', text: 'Regreso garantizado bajo solicitud' },
+          { icon: '✅', text: 'SUV premium o sedán ejecutivo' },
+          { icon: '✅', text: 'Conductor fluido en inglés' },
+          { icon: '✅', text: 'Acreditación de seguridad OTAN' },
+          { icon: '✅', text: 'Pago en efectivo en euros' },
+        ],
+        button: 'Reservar traslado',
+        whatsapp: 'O escríbenos por WhatsApp: ',
+      },
+      {
+        borderClass: 'border-primary',
+        circleClass: 'bg-gradient-to-br from-primary to-primary/70',
+        priceClass: 'text-primary',
+        buttonClass:
+          'from-secondary to-secondary/80 hover:from-secondary/80 hover:to-secondary text-secondary-foreground',
+        price: '€60',
+        title: 'Base → Banská Bystrica',
+        subtitle: 'Traslado solo ida a Banská Bystrica',
+        features: [
+          { icon: '✅', text: '25% de descuento militar ya aplicado' },
+          { icon: '✅', text: 'Tiempo medio de llegada 30–40 min según disponibilidad' },
+          { icon: '✅', text: 'Regreso garantizado bajo solicitud' },
+          { icon: '✅', text: 'SUV premium o sedán ejecutivo' },
+          { icon: '✅', text: 'Conductor fluido en inglés' },
+          { icon: '✅', text: 'Acreditación de seguridad OTAN' },
+          { icon: '✅', text: 'Pago en efectivo en euros' },
+        ],
+        button: 'Reservar traslado',
+        whatsapp: 'O escríbenos por WhatsApp: ',
+      },
+    ],
+    badges: ['🛡️ Verificado por la OTAN', '📱 Confirmación inmediata', '⭐ Valoración 4.9/5', '🇪🇸 Atención en español'],
+  },
+};
+
 const PricingSection = () => {
-  return <section className="py-12 sm:py-20 px-4 sm:px-6 bg-gradient-to-b from-muted to-background">
+  const { language } = useLanguage();
+  const content = translations[language];
+
+  return (
+    <section className="py-12 sm:py-20 px-4 sm:px-6 bg-gradient-to-b from-muted to-background">
       <div className="max-w-4xl mx-auto text-center">
         <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-4 text-gradient-gold">
-          Cenník služieb
+          {content.heading}
         </h2>
         <p className="text-base sm:text-lg text-muted-foreground mb-8 sm:mb-12">
-          Profesionálne ceny pre španielsky vojenský personál
+          {content.description}
         </p>
 
         <div className="grid md:grid-cols-2 gap-6 sm:gap-8 max-w-5xl mx-auto">
-          <Card className="
-            relative bg-card/50 backdrop-blur-md
-            border-2 border-secondary overflow-hidden
-            hover-military
-          ">
-            <Badge className="
-                absolute -top-2 -right-10 sm:-right-12 bg-primary text-primary-foreground
-                px-6 sm:px-8 py-1 rotate-45 origin-center font-bold text-xs sm:text-sm
-              ">
-              NAJPOPULÁRNEJŠIE
-            </Badge>
+          {content.cards.map((card) => (
+            <Card
+              key={card.title}
+              className={`relative bg-card/50 backdrop-blur-md border-2 overflow-hidden hover-military ${card.borderClass}`}
+            >
+              {card.highlight && card.highlightClass && (
+                <Badge
+                  className={`absolute -top-2 -right-10 sm:-right-12 px-6 sm:px-8 py-1 rotate-45 origin-center font-bold text-xs sm:text-sm ${card.highlightClass}`}
+                >
+                  {card.highlight}
+                </Badge>
+              )}
 
-            <CardHeader className="relative">
-              <div className="absolute top-4 left-4 w-12 h-12 sm:w-14 sm:h-14 md:w-16 md:h-16 bg-gradient-to-br from-secondary to-secondary/70 rounded-full flex items-center justify-center">
-                <span className="text-secondary-foreground font-black text-xl sm:text-2xl">€</span>
-              </div>
-
-              <div className="pt-8">
-                <div className="text-3xl sm:text-4xl md:text-5xl font-black text-secondary mb-2">€35</div>
-                <h3 className="text-xl sm:text-2xl font-bold text-foreground">Základňa → Zvolen</h3>
-                <p className="text-sm sm:text-base text-muted-foreground">Jednosmerná preprava do Zvolena</p>
-              </div>
-            </CardHeader>
-
-            <CardContent className="space-y-3 sm:space-y-4">
-
-              <div className="text-left space-y-2 sm:space-y-3 text-sm">
-                {["✅ 25% vojenská zľava už aplikovaná", "✅ Priemerný čas príchodu 30 – 40 min podľa dostupnosti", "✅ Garantovaná spiatočná cesta", "✅ Prémiové vozidlo", "✅ Vodič hovoriaci iba po anglicky", "✅ Bezpečnostné overenie NATO", "✅ Platba výlučne v hotovosti"].map((feature, index) => <div key={index} className="flex items-center gap-2 sm:gap-3">
-                    <span className="text-secondary text-base">{feature.split(' ')[0]}</span>
-                    <span className="text-foreground text-xs sm:text-sm">{feature.substring(2)}</span>
-                  </div>)}
-              </div>
-
-              <div className="pt-4 sm:pt-6 space-y-3 sm:space-y-4">
-                <Button size="lg" className="
-                    w-full bg-gradient-to-r from-primary to-primary-glow
-                    hover:from-primary-glow hover:to-primary
-                    text-primary-foreground font-bold py-3 sm:py-4 text-base sm:text-lg
-                    rounded-full shadow-xl hover-military
-                  " asChild>
-                  <a href="tel:+421919040118">
-                    📞 Rezervovať
-                  </a>
-                </Button>
-
-                <div className="text-center">
-                  <p className="text-xs sm:text-sm text-muted-foreground">
-                    Alebo napíšte na WhatsApp: <span className="text-secondary font-bold">+421919040118</span>
-                  </p>
+              <CardHeader className="relative">
+                <div
+                  className={`absolute top-4 left-4 w-12 h-12 sm:w-14 sm:h-14 md:w-16 md:h-16 rounded-full flex items-center justify-center text-white font-black text-xl sm:text-2xl ${card.circleClass}`}
+                >
+                  €
                 </div>
-              </div>
-            </CardContent>
-          </Card>
 
-          <Card className="
-            relative bg-card/50 backdrop-blur-md 
-            border-2 border-primary overflow-hidden
-            hover-military
-          ">
-            <CardHeader className="relative">
-              <div className="absolute top-4 left-4 w-12 h-12 sm:w-14 sm:h-14 md:w-16 md:h-16 bg-gradient-to-br from-primary to-primary/70 rounded-full flex items-center justify-center">
-                <span className="text-primary-foreground font-black text-xl sm:text-2xl">€</span>
-              </div>
-
-              <div className="pt-8">
-                <div className="text-3xl sm:text-4xl md:text-5xl font-black text-primary mb-2">€60</div>
-                <h3 className="text-xl sm:text-2xl font-bold text-foreground">Základňa → B. Bystrica</h3>
-                <p className="text-sm sm:text-base text-muted-foreground">Jednosmerná preprava do Banskej Bystrice</p>
-              </div>
-            </CardHeader>
-
-            <CardContent className="space-y-3 sm:space-y-4">
-
-              <div className="text-left space-y-2 sm:space-y-3 text-sm">
-                {["✅ 25% vojenská zľava už aplikovaná", "✅ Priemerný čas príchodu 30 – 40 min podľa dostupnosti", "✅ Garantovaná spiatočná cesta", "✅ Prémiové vozidlo", "✅ Vodič hovoriaci iba po anglicky", "✅ Bezpečnostné overenie NATO", "✅ Platba výlučne v hotovosti"].map((feature, index) => <div key={index} className="flex items-center gap-2 sm:gap-3">
-                    <span className="text-secondary text-base">{feature.split(' ')[0]}</span>
-                    <span className="text-foreground text-xs sm:text-sm">{feature.substring(2)}</span>
-                  </div>)}
-              </div>
-
-              <div className="pt-4 sm:pt-6 space-y-3 sm:space-y-4">
-                <Button size="lg" className="
-                    w-full bg-gradient-to-r from-secondary to-secondary/80
-                    hover:from-secondary/80 hover:to-secondary
-                    text-secondary-foreground font-bold py-3 sm:py-4 text-base sm:text-lg
-                    rounded-full shadow-xl hover-military
-                  " asChild>
-                  <a href="tel:+421919040118">
-                    📞 Rezervovať
-                  </a>
-                </Button>
-
-                <div className="text-center">
-                  <p className="text-xs sm:text-sm text-muted-foreground">
-                    Alebo napíšte na WhatsApp: <span className="text-secondary font-bold">+421919040118</span>
-                  </p>
+                <div className="pt-8">
+                  <div className={`text-3xl sm:text-4xl md:text-5xl font-black mb-2 ${card.priceClass}`}>
+                    {card.price}
+                  </div>
+                  <h3 className="text-xl sm:text-2xl font-bold text-foreground">{card.title}</h3>
+                  <p className="text-sm sm:text-base text-muted-foreground">{card.subtitle}</p>
                 </div>
-              </div>
-            </CardContent>
-          </Card>
+              </CardHeader>
+
+              <CardContent className="space-y-3 sm:space-y-4">
+                <div className="text-left space-y-2 sm:space-y-3 text-sm">
+                  {card.features.map((feature) => (
+                    <div key={feature.text} className="flex items-center gap-2 sm:gap-3">
+                      <span className="text-secondary text-base">{feature.icon}</span>
+                      <span className="text-foreground text-xs sm:text-sm">{feature.text}</span>
+                    </div>
+                  ))}
+                </div>
+
+                <div className="pt-4 sm:pt-6 space-y-3 sm:space-y-4">
+                  <Button
+                    size="lg"
+                    className={`w-full font-bold py-3 sm:py-4 text-base sm:text-lg rounded-full shadow-xl hover-military bg-gradient-to-r ${card.buttonClass}`}
+                    asChild
+                  >
+                    <a href="tel:+421919040118">📞 {card.button}</a>
+                  </Button>
+
+                  <div className="text-center">
+                    <p className="text-xs sm:text-sm text-muted-foreground">
+                      {card.whatsapp}
+                      <span className="text-secondary font-bold">+421919040118</span>
+                    </p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
         </div>
 
         <div className="mt-10 sm:mt-12 flex flex-wrap justify-center gap-3 sm:gap-4">
-          {["🛡️ NATO verifikované", "📱 Okamžité potvrdenie", "⭐ 4.9/5 hodnotenie", "🇪🇸 Španielsky friendly"].map((badge, index) => <div key={index} className="bg-secondary/10 backdrop-blur-md border border-secondary/30 rounded-full px-3 py-2 text-xs sm:text-sm font-medium">
+          {content.badges.map((badge) => (
+            <div
+              key={badge}
+              className="bg-secondary/10 backdrop-blur-md border border-secondary/30 rounded-full px-3 py-2 text-xs sm:text-sm font-medium"
+            >
               {badge}
-            </div>)}
+            </div>
+          ))}
         </div>
       </div>
-    </section>;
+    </section>
+  );
 };
 
 export default PricingSection;

--- a/src/components/RouteSection.tsx
+++ b/src/components/RouteSection.tsx
@@ -1,55 +1,117 @@
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { useLanguage } from '@/contexts/LanguageContext';
 
-const routes = [
-  {
-    title: 'Lešť → Zvolen',
-    duration: '35 min',
-    highlights: ['Priamy vstup cez vojenskú bránu', 'Koordinácia vyzdvihnutia bez zbytočného čakania', 'Odporúčané bary: Quadra, Retro'],
+const translations = {
+  en: {
+    badge: 'Operational routes',
+    heading: 'Primary connections for the Spanish unit',
+    description:
+      'Optimised routes between the Lešť training area, Zvolen and Banská Bystrica. Designed for both leisure time and duty transfers.',
+    routes: [
+      {
+        title: 'Lešť → Zvolen',
+        duration: '35 min',
+        highlights: [
+          'Direct entry at the military gate',
+          'Coordinated pick-up without unnecessary waiting',
+          'Recommended bars: Quadra, Retro',
+        ],
+      },
+      {
+        title: 'Lešť → Banská Bystrica',
+        duration: '50 min',
+        highlights: [
+          'Drop-off at SNP Square and Europa Shopping Center',
+          'Coordination with Ministry, Klub 77 and partner venues',
+          'Cash payment collected upon boarding',
+        ],
+      },
+    ],
+    steps: [
+      {
+        title: '1. Booking',
+        detail: 'Call or WhatsApp. We confirm pick-up time and passenger count.',
+        sub: 'English & Español friendly',
+      },
+      {
+        title: '2. Pick-up',
+        detail: 'Driver waits at the Lešť gate. We track unit schedule changes in real time.',
+        sub: 'Vehicle and driver identification in advance',
+      },
+      {
+        title: '3. Return',
+        detail: 'Precise return time coordinated back to base, even at the last minute.',
+        sub: 'Availability guaranteed 24/7',
+      },
+    ],
   },
-  {
-    title: 'Lešť → Banská Bystrica',
-    duration: '50 min',
-    highlights: ['Transfer na Námestie SNP a Europa Shopping Center', 'Koordinácia s nočnými klubmi Ministry, Klub 77', 'Platba výlučne v hotovosti pri nástupe'],
+  es: {
+    badge: 'Rutas operativas',
+    heading: 'Conexiones principales para la unidad española',
+    description:
+      'Rutas optimizadas entre el área de entrenamiento de Lešť, Zvolen y Banská Bystrica. Diseñadas para traslados de ocio y servicio.',
+    routes: [
+      {
+        title: 'Lešť → Zvolen',
+        duration: '35 min',
+        highlights: [
+          'Acceso directo por la puerta militar',
+          'Recogida coordinada sin esperas innecesarias',
+          'Bares recomendados: Quadra, Retro',
+        ],
+      },
+      {
+        title: 'Lešť → Banská Bystrica',
+        duration: '50 min',
+        highlights: [
+          'Llegada a la Plaza SNP y Europa Shopping Center',
+          'Coordinación con Ministry, Klub 77 y locales asociados',
+          'Cobro en efectivo al embarcar',
+        ],
+      },
+    ],
+    steps: [
+      {
+        title: '1. Reserva',
+        detail: 'Llamada o WhatsApp. Confirmamos hora de recogida y número de pasajeros.',
+        sub: 'Atención en inglés y español',
+      },
+      {
+        title: '2. Recogida',
+        detail: 'El conductor espera en la puerta de Lešť. Seguimos cambios en el programa en tiempo real.',
+        sub: 'Identificación del vehículo y conductor por adelantado',
+      },
+      {
+        title: '3. Regreso',
+        detail: 'Coordinamos la hora exacta de vuelta a la base, incluso en el último momento.',
+        sub: 'Disponibilidad garantizada 24/7',
+      },
+    ],
   },
-];
-
-const steps = [
-  {
-    title: '1. Rezervácia',
-    detail: 'Telefonát alebo WhatsApp. Potvrdíme čas vyzdvihnutia a počet pasažierov.',
-    sub: 'English & Español friendly',
-  },
-  {
-    title: '2. Vyzdvihnutie',
-    detail: 'Vodič čaká pri bráne Lešť. Sledujeme zmeny programu jednotky v reálnom čase.',
-    sub: 'Identifikácia vozidla a vodiča vopred',
-  },
-  {
-    title: '3. Návrat',
-    detail: 'Koordinujeme presný čas odchodu späť na základňu, vrátane poslednej chvíle.',
-    sub: 'Garancia dostupnosti 24/7',
-  },
-];
+} as const;
 
 const RouteSection = () => {
+  const { language } = useLanguage();
+  const content = translations[language];
+
   return (
     <section className="py-12 sm:py-20 px-4 sm:px-6 bg-gradient-to-br from-primary/5 via-background to-secondary/5">
       <div className="max-w-6xl mx-auto space-y-10 sm:space-y-16">
         <div className="text-center space-y-3 sm:space-y-4">
           <Badge className="bg-secondary/20 text-secondary border-secondary/40 uppercase tracking-wide">
-            Operačné trasy
+            {content.badge}
           </Badge>
           <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold text-gradient-military">
-            Primárne spojenia pre španielsku jednotku
+            {content.heading}
           </h2>
           <p className="text-base sm:text-lg text-muted-foreground max-w-3xl mx-auto">
-            Optimalizované trasy medzi výcvikovým priestorom Lešť, mestom Zvolen a Banskou Bystricou. Zohľadňujeme služby pre voľnočasové aj služobné presuny.
+            {content.description}
           </p>
         </div>
 
         <div className="grid grid-cols-1 min-[480px]:grid-cols-2 md:grid-cols-2 gap-5 sm:gap-6 md:gap-8">
-          {routes.map((route) => (
+          {content.routes.map((route) => (
             <Card
               key={route.title}
               className="bg-card/70 backdrop-blur border border-secondary/30 hover:border-secondary/60 transition-all duration-300 hover-military"
@@ -75,7 +137,7 @@ const RouteSection = () => {
         </div>
 
         <div className="grid grid-cols-1 min-[460px]:grid-cols-2 sm:grid-cols-3 gap-4 sm:gap-6">
-          {steps.map((step) => (
+          {content.steps.map((step) => (
             <div
               key={step.title}
               className="bg-black/30 border border-secondary/20 rounded-2xl p-4 sm:p-5 space-y-2 sm:space-y-3 text-center backdrop-blur hover:border-secondary/50 transition-all"

--- a/src/components/SeoContentSection.tsx
+++ b/src/components/SeoContentSection.tsx
@@ -1,36 +1,99 @@
+import type { ReactNode } from 'react';
+import { useLanguage } from '@/contexts/LanguageContext';
+
+interface SeoSection {
+  title: string;
+  paragraphs: ReactNode[];
+}
+
+const translations: Record<
+  'en' | 'es',
+  {
+    heading: string;
+    intro: ReactNode;
+    sections: SeoSection[];
+  }
+> = {
+  en: {
+    heading: 'Taxi for Spanish troops from Lešť base',
+    intro:
+      'TaxiForce is a specialised transfer service based in central Slovakia. Since 2022 we have ensured safe and comfortable links between the Lešť training area, the city of Zvolen and Banská Bystrica.',
+    sections: [
+      {
+        title: 'Professional focus on NATO missions',
+        paragraphs: [
+          'Our vehicles meet strict maintenance standards and are equipped for long transfers and night returns. Every driver is vetted, experienced with international units and familiar with military terminology. The service is tailored to the Spanish contingent while respecting confidentiality protocols.',
+        ],
+      },
+      {
+        title: 'Coverage for Zvolen and Banská Bystrica',
+        paragraphs: [
+          'We frequently arrange transfers to Zvolen Castle, SNP Square, Europa Shopping Center, OC Terminal, downtown Banská Bystrica restaurants and popular venues such as Ministry of Fun, Klub 77 or Bar Murgaš. Upon request we organise trips to the Tatras or Budapest.',
+        ],
+      },
+      {
+        title: 'SEO and online visibility',
+        paragraphs: [
+          (
+            <>
+              TaxiForce targets key phrases such as <strong>taxi Lešť Zvolen</strong>, <strong>military taxi Slovakia</strong>, <strong>transport Spanish Army Slovakia</strong> and <strong>Lešť Banská Bystrica transfer</strong>. With optimised content, reviews and rapid contact, we provide a trusted logistics partner for international units in Slovakia.
+            </>
+          ),
+        ],
+      },
+    ],
+  },
+  es: {
+    heading: 'Taxi para las tropas españolas desde la base de Lešť',
+    intro:
+      'TaxiForce es un servicio de traslados especializado con base en el centro de Eslovaquia. Desde 2022 garantizamos conexiones seguras y cómodas entre el área de entrenamiento de Lešť, la ciudad de Zvolen y Banská Bystrica.',
+    sections: [
+      {
+        title: 'Profesionalidad enfocada en misiones de la OTAN',
+        paragraphs: [
+          'Nuestros vehículos cumplen exigentes estándares técnicos y están preparados para traslados largos y regresos nocturnos. Cada conductor está verificado, trabaja con unidades internacionales y domina la terminología militar. El servicio se adapta al contingente español respetando los protocolos de confidencialidad.',
+        ],
+      },
+      {
+        title: 'Cobertura para Zvolen y Banská Bystrica',
+        paragraphs: [
+          'Realizamos traslados frecuentes al Castillo de Zvolen, la Plaza SNP, Europa Shopping Center, OC Terminal, restaurantes del centro de Banská Bystrica y locales populares como Ministry of Fun, Klub 77 o Bar Murgaš. También organizamos excursiones a los Tatras o Budapest bajo solicitud.',
+        ],
+      },
+      {
+        title: 'SEO y visibilidad online',
+        paragraphs: [
+          (
+            <>
+              TaxiForce trabaja palabras clave como <strong>taxi Lešť Zvolen</strong>, <strong>military taxi Slovakia</strong>, <strong>transport Spanish Army Slovakia</strong> y <strong>Lešť Banská Bystrica transfer</strong>. Con contenido optimizado, reseñas y contacto inmediato, ofrecemos un socio logístico fiable para unidades internacionales en Eslovaquia.
+            </>
+          ),
+        ],
+      },
+    ],
+  },
+};
+
 const SeoContentSection = () => {
+  const { language } = useLanguage();
+  const content = translations[language];
+
   return (
     <section className="py-12 sm:py-20 px-4 sm:px-6 bg-background">
       <article className="max-w-5xl mx-auto space-y-8 sm:space-y-10 text-muted-foreground leading-relaxed text-sm sm:text-base">
         <header className="space-y-3 sm:space-y-4 text-center">
-          <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold text-gradient-gold">
-            Taxi pre španielskych vojakov zo základne Lešť
-          </h2>
-          <p className="text-sm sm:text-base md:text-lg">
-            TaxiForce je špecializovaná prepravná služba so sídlom v Banskobystrickom kraji. Už od roku 2022 zabezpečujeme komfortné a bezpečné spojenie medzi Výcvikovým priestorom Lešť, mestom Zvolen a Banskou Bystricou.
-          </p>
+          <h2 className="text-2xl sm:text-3xl md:text-4xl font-bold text-gradient-gold">{content.heading}</h2>
+          <p className="text-sm sm:text-base md:text-lg">{content.intro}</p>
         </header>
 
-        <section className="space-y-3 sm:space-y-4">
-          <h3 className="text-xl sm:text-2xl font-semibold text-secondary">Profesionalita so zameraním na NATO misie</h3>
-          <p>
-            Naše vozidlá spĺňajú prísne požiadavky na technický stav a sú vybavené na dlhé presuny aj nočné návraty. Každý vodič je preverovaný, má skúsenosti s medzinárodnými jednotkami a rozumie vojenskej terminológii. Služba je prispôsobená potrebám španielskeho kontingentu a rešpektuje režim utajenia.
-          </p>
-        </section>
-
-        <section className="space-y-3 sm:space-y-4">
-          <h3 className="text-xl sm:text-2xl font-semibold text-secondary">Pokrytie pre Zvolen aj Banskú Bystricu</h3>
-          <p>
-            Najčastejšie zabezpečujeme transfery na Zvolenský zámok, námestie vo Zvolene, Europa SC, OC Terminal, reštaurácie v centre Banskej Bystrice a populárne podniky ako Ministry of Fun, Klub 77 či Bar Murgaš. Po dohode vieme zabezpečiť aj výlety do Tatier alebo Budapešti.
-          </p>
-        </section>
-
-        <section className="space-y-3 sm:space-y-4">
-          <h3 className="text-xl sm:text-2xl font-semibold text-secondary">SEO a online viditeľnosť</h3>
-          <p>
-            TaxiForce sa zameriava na kľúčové frázy ako <strong>taxi Lešť Zvolen</strong>, <strong>vojenské taxi Slovensko</strong>, <strong>transport Spanish Army Slovakia</strong> a <strong>Lešť Banská Bystrica transfer</strong>. Vďaka optimalizovanému obsahu, recenziám a rýchlemu kontaktu získate spoľahlivého partnera pre logistiku medzinárodných jednotiek na Slovensku.
-          </p>
-        </section>
+        {content.sections.map((section) => (
+          <section key={section.title} className="space-y-3 sm:space-y-4">
+            <h3 className="text-xl sm:text-2xl font-semibold text-secondary">{section.title}</h3>
+            {section.paragraphs.map((paragraph, index) => (
+              <p key={index}>{paragraph}</p>
+            ))}
+          </section>
+        ))}
       </article>
     </section>
   );

--- a/src/components/TestimonialsSection.tsx
+++ b/src/components/TestimonialsSection.tsx
@@ -1,54 +1,97 @@
 import { Card, CardContent } from '@/components/ui/card';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 import sergeantImage from '@/assets/sergeant-testimonial.jpg';
+import { useLanguage } from '@/contexts/LanguageContext';
 
-const testimonials = [
-  {
-    name: "Seržant M. Rodriguez",
-    rank: "Španielska armáda",
-    avatar: sergeantImage,
-    fallback: "MR",
-    rating: 5,
-    text: "Konečne, taxi služba, ktorá to chápe. Profesionálna, diskrétna a poznajú všetky dobré tapas miesta v Banskej Bystrici!",
-    bgColor: "bg-military-green",
+const translations = {
+  en: {
+    heading: 'What our Spanish military partners say',
+    subheading: 'More than 200 Spanish service members rely on TaxiForce.',
+    stats: ['Rating: 4.9/5', '200+ satisfied soldiers', 'NATO verified'],
+    testimonials: [
+      {
+        name: 'Sergeant M. Rodriguez',
+        rank: 'Spanish Army',
+        avatar: sergeantImage,
+        fallback: 'MR',
+        rating: 5,
+        text: 'Finally a taxi service that gets it. Professional, discreet and they know every great tapas spot in Banská Bystrica!',
+        bgColor: 'bg-military-green',
+      },
+      {
+        name: 'Captain A. García',
+        rank: 'Spanish Air Force',
+        avatar: null,
+        fallback: 'AG',
+        rating: 5,
+        text: 'Used them for an evening in Zvolen. The driver waited while we enjoyed dinner, then brought us back to base safely. Military efficiency!',
+        bgColor: 'bg-military-blue',
+      },
+      {
+        name: 'Lieutenant C. Fernández',
+        rank: 'Spanish Navy',
+        avatar: null,
+        fallback: 'CF',
+        rating: 5,
+        text: 'Best investment for downtime. No worries about driving after a few cervezas. ¡Excellent service!',
+        bgColor: 'bg-military-navy',
+      },
+    ],
   },
-  {
-    name: "Kapitán A. García",
-    rank: "Španielske letectvo",
-    avatar: null,
-    fallback: "AG",
-    rating: 5,
-    text: "Použil som ich na večer v Zvolene. Vodič čakal, kým sme si vychutnali večeru, potom nás dostal späť na základňu bezpečne. Vojenská efektivita!",
-    bgColor: "bg-military-blue",
+  es: {
+    heading: 'Opiniones de nuestros aliados españoles',
+    subheading: 'Más de 200 militares españoles confían en TaxiForce.',
+    stats: ['Valoración: 4.9/5', '200+ soldados satisfechos', 'Verificado por la OTAN'],
+    testimonials: [
+      {
+        name: 'Sargento M. Rodriguez',
+        rank: 'Ejército de Tierra',
+        avatar: sergeantImage,
+        fallback: 'MR',
+        rating: 5,
+        text: 'Por fin un taxi que lo entiende. Profesional, discreto y conocen todos los mejores sitios de tapas en Banská Bystrica.',
+        bgColor: 'bg-military-green',
+      },
+      {
+        name: 'Capitán A. García',
+        rank: 'Ejército del Aire',
+        avatar: null,
+        fallback: 'AG',
+        rating: 5,
+        text: 'Los contraté para una noche en Zvolen. El chofer esperó mientras cenábamos y nos llevó de vuelta a la base con seguridad. ¡Eficiencia militar!',
+        bgColor: 'bg-military-blue',
+      },
+      {
+        name: 'Teniente C. Fernández',
+        rank: 'Armada Española',
+        avatar: null,
+        fallback: 'CF',
+        rating: 5,
+        text: 'La mejor inversión para el tiempo libre. Sin preocupaciones por conducir después de unas cervezas. ¡Servicio excelente!',
+        bgColor: 'bg-military-navy',
+      },
+    ],
   },
-  {
-    name: "Poručík C. Fernández",
-    rank: "Španielske námorníctvo",
-    avatar: null,
-    fallback: "CF",
-    rating: 5,
-    text: "Najlepšia investícia do voľného času. Žiadne starosti s riadením po pár cervezách. ¡Excelente servicio!",
-    bgColor: "bg-military-navy",
-  },
-];
+} as const;
 
 const TestimonialsSection = () => {
+  const { language } = useLanguage();
+  const content = translations[language];
+
   return (
     <section className="py-12 sm:py-20 px-4 sm:px-6 bg-gradient-to-r from-primary/5 via-secondary/5 to-primary/5">
       <div className="max-w-5xl mx-auto">
         <div className="text-center mb-10 sm:mb-16">
           <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-4 text-gradient-military">
-            Čo hovoria naši španielski vojenskí bratia
+            {content.heading}
           </h2>
-          <p className="text-base sm:text-lg text-muted-foreground">
-            Už viac ako 200 španielskych vojenských pracovníkov dôveruje TaxiForce
-          </p>
+          <p className="text-base sm:text-lg text-muted-foreground">{content.subheading}</p>
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5 sm:gap-6 lg:gap-8">
-          {testimonials.map((testimonial, index) => (
+          {content.testimonials.map((testimonial, index) => (
             <Card
-              key={index}
+              key={testimonial.name}
               className="
                 bg-card/80 backdrop-blur-md border-l-4 border-secondary
                 hover:border-l-primary transition-all duration-300
@@ -89,11 +132,14 @@ const TestimonialsSection = () => {
 
         <div className="text-center mt-10 sm:mt-12">
           <div className="inline-flex flex-wrap items-center justify-center gap-2 sm:gap-4 bg-secondary/10 backdrop-blur-md rounded-full px-4 sm:px-6 py-2 sm:py-3 border border-secondary/30 text-xs sm:text-sm">
-            <span className="text-secondary font-semibold sm:font-bold">Hodnotenie: 4.9/5</span>
-            <div className="hidden sm:block w-px h-4 bg-secondary/30" />
-            <span className="text-secondary font-semibold sm:font-bold">200+ spokojných vojakov</span>
-            <div className="hidden sm:block w-px h-4 bg-secondary/30" />
-            <span className="text-secondary font-semibold sm:font-bold">NATO overené</span>
+            {content.stats.map((stat, index) => (
+              <span key={stat} className="flex items-center gap-2 text-secondary font-semibold sm:font-bold">
+                {stat}
+                {index < content.stats.length - 1 && (
+                  <span className="hidden sm:inline w-px h-4 bg-secondary/30" aria-hidden="true" />
+                )}
+              </span>
+            ))}
           </div>
         </div>
       </div>

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -1,0 +1,31 @@
+import { createContext, useContext, useState, type ReactNode } from 'react';
+
+export type Language = 'en' | 'es';
+
+interface LanguageContextValue {
+  language: Language;
+  setLanguage: (language: Language) => void;
+}
+
+const LanguageContext = createContext<LanguageContextValue | undefined>(undefined);
+
+export const LanguageProvider = ({ children }: { children: ReactNode }) => {
+  const [language, setLanguage] = useState<Language>('en');
+
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const useLanguage = () => {
+  const context = useContext(LanguageContext);
+
+  if (!context) {
+    throw new Error('useLanguage must be used within a LanguageProvider');
+  }
+
+  return context;
+};

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -8,10 +8,12 @@ import FaqSection from '@/components/FaqSection';
 import SeoContentSection from '@/components/SeoContentSection';
 import ContactSection from '@/components/ContactSection';
 import BlogSection from '@/components/BlogSection';
+import LanguageSwitcher from '@/components/LanguageSwitcher';
 
 const Index = () => {
   return (
     <div className="min-h-screen bg-background">
+      <LanguageSwitcher />
       <main>
         <HeroSection />
         <FeaturesSection />


### PR DESCRIPTION
## Summary
- introduce a global language context and floating switcher to toggle between English and Spanish on the landing page
- rewrite hero, marketing and support sections to pull content from bilingual translation tables instead of Slovak copy
- refresh pricing and contact details with English/Spanish copy, keeping consistent styling and removing Slovak wording

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4d1637f708323aa366e304d83f177