### PR TITLE
Add Slavia 1 focus and refresh SEO copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>TaxiForce | Vojenské taxi Lešť - Zvolen & Banská Bystrica pre španielsku armádu</title>
-    <meta name="description" content="TaxiForce zabezpečuje 24/7 transfery zo základne Lešť do miest Zvolen a Banská Bystrica pre španielsky vojenský personál. NATO preverení vodiči, garantované návraty a podpora v angličtine aj španielčine." />
-    <meta name="keywords" content="taxi lešť, vojenské taxi slovensko, transfer lešť zvolen, transfer lešť banská bystrica, taxi pre španielsku armádu, military taxi slovakia, taxi force" />
+    <meta name="description" content="TaxiForce zabezpečuje 24/7 transfery zo základne Lešť (Slavia 1) do miest Zvolen a Banská Bystrica pre španielsky vojenský personál. NATO preverení vodiči, garantované návraty a podpora v angličtine aj španielčine." />
+    <meta name="keywords" content="taxi lešť, slavia 1, taxi slavia 1 lešť, vojenské taxi slovensko, transfer lešť zvolen, transfer lešť banská bystrica, taxi pre španielsku armádu, military taxi slovakia, taxi force" />
     <meta name="author" content="TaxiForce" />
     <meta name="robots" content="index, follow" />
     <link rel="canonical" href="https://taxiforce.sk" />
@@ -14,7 +14,7 @@
     <link rel="alternate" href="https://taxiforce.sk" hreflang="x-default" />
 
     <meta property="og:title" content="TaxiForce | Military taxi Lešť - Zvolen & Banská Bystrica" />
-    <meta property="og:description" content="Špecializované transfery pre španielsky kontingent na Slovensku. 24/7 dispečing, NATO security cleared vodiči a garantované návraty." />
+    <meta property="og:description" content="Špecializované transfery pre španielsky kontingent na Slovensku. Slavia 1 dispečing, 24/7 služby, NATO security cleared vodiči a garantované návraty." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://taxiforce.sk" />
     <meta property="og:image" content="https://taxiforce.sk/hero-image.jpg" />
@@ -24,12 +24,12 @@
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="TaxiForce | Military taxi Slovakia" />
-    <meta name="twitter:description" content="24/7 transfers pre španielsku armádu medzi Lešťom, Zvolenom a Banskou Bystricou. NATO preverení vodiči." />
+    <meta name="twitter:description" content="24/7 transfers pre španielsku armádu zo Slavia 1 na základni Lešť do Zvolena a Banskej Bystrice. NATO preverení vodiči." />
     <meta name="twitter:image" content="https://taxiforce.sk/hero-image.jpg" />
     <meta name="twitter:site" content="@taxiforce" />
 
     <meta name="geo.region" content="SK-BC" />
-    <meta name="geo.placename" content="Lešť, Zvolen, Banská Bystrica" />
+    <meta name="geo.placename" content="Lešť Slavia 1, Zvolen, Banská Bystrica" />
     <meta name="geo.position" content="48.585;19.129" />
     <meta name="ICBM" content="48.585, 19.129" />
 
@@ -39,10 +39,10 @@
         "@type": "LocalBusiness",
         "name": "TaxiForce",
         "image": "https://taxiforce.sk/hero-image.jpg",
-        "description": "Špecializované taxi pre španielsky vojenský personál medzi základňou Lešť, Zvolenom a Banskou Bystricou.",
+        "description": "Špecializované taxi pre španielsky vojenský personál medzi základňou Lešť (Slavia 1), Zvolenom a Banskou Bystricou.",
         "url": "https://taxiforce.sk",
         "telephone": "+421919040118",
-        "areaServed": ["Lešť", "Zvolen", "Banská Bystrica"],
+        "areaServed": ["Lešť Slavia 1", "Zvolen", "Banská Bystrica"],
         "serviceType": "Military taxi transfers",
         "openingHours": "Mo-Su 00:00-23:59",
         "priceRange": "€€",

--- a/src/components/FaqSection.tsx
+++ b/src/components/FaqSection.tsx
@@ -9,7 +9,8 @@ const translations = {
     faqs: [
       {
         question: 'How fast can you reach Lešť base?',
-        answer: 'We usually depart within 8 minutes after confirmation. During large exercises we activate additional vehicles.',
+        answer:
+          'We usually depart within 8 minutes after confirmation. Drivers remain staged near the Slavia 1 call point and we activate additional vehicles during large exercises.',
         note: '¿Cuánto tardan en llegar a la base de Lešť? — Salimos en un máximo de 8 minutos tras la confirmación, incluso durante maniobras.',
       },
       {
@@ -39,7 +40,7 @@ const translations = {
       {
         question: '¿En cuánto tiempo pueden llegar a la base de Lešť?',
         answer:
-          'Salimos normalmente en un máximo de 8 minutos tras confirmar la reserva. En grandes maniobras activamos vehículos de refuerzo.',
+          'Salimos normalmente en un máximo de 8 minutos tras confirmar la reserva. El conductor permanece ubicado junto al punto de llamada Slavia 1 y en grandes maniobras activamos vehículos de refuerzo.',
         note: 'How fast can you reach Lešť base? — We depart within 8 minutes after confirmation, even during exercises.',
       },
       {

--- a/src/components/FeaturesSection.tsx
+++ b/src/components/FeaturesSection.tsx
@@ -8,13 +8,14 @@ import { useLanguage } from '@/contexts/LanguageContext';
 const translations = {
   en: {
     heading: 'Why choose TaxiForce?',
-    description: 'Specialised transfer unit dedicated to Spanish military personnel deployed at Lešť base.',
+    description:
+      'Specialised transfer unit dedicated to Spanish military personnel deployed at Lešť base with dispatch anchored at the Slavia 1 call point.',
     features: [
       {
         icon: '🚐',
         title: 'Direct connection Lešť → Zvolen / Banská Bystrica',
         description:
-          'We monitor troop movements and coordinate pick-ups at the base gate. Vehicles usually arrive within 30–40 minutes.',
+          'We monitor troop movements and coordinate pick-ups at the Slavia 1 gate. Vehicles usually arrive within 30–40 minutes.',
         image: taxiImage,
         badge: '24/7 dispatch',
       },
@@ -62,13 +63,14 @@ const translations = {
   },
   es: {
     heading: '¿Por qué elegir TaxiForce?',
-    description: 'Unidad de traslados especializada para el personal militar español destacado en la base de Lešť.',
+    description:
+      'Unidad de traslados especializada para el personal militar español destacado en la base de Lešť con central operativa en el punto de llamada Slavia 1.',
     features: [
       {
         icon: '🚐',
         title: 'Conexión directa Lešť → Zvolen / Banská Bystrica',
         description:
-          'Supervisamos los movimientos de la unidad y coordinamos recogidas en la puerta de la base. El vehículo llega en 30–40 minutos.',
+          'Supervisamos los movimientos de la unidad y coordinamos recogidas en la puerta Slavia 1. El vehículo llega en 30–40 minutos.',
         image: taxiImage,
         badge: 'Central 24/7',
       },

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -4,11 +4,11 @@ import { useLanguage } from '@/contexts/LanguageContext';
 
 const translations = {
   en: {
-    routeBadge: '🇪🇸 Base Training Area Lešť → Zvolen / Banská Bystrica',
+    routeBadge: '🇪🇸 Slavia 1 Lešť base → Zvolen / Banská Bystrica',
     serviceBadge: 'NATO vetted • Discreet 24/7',
     heading: 'TaxiForce Military Transfers',
     description:
-      'Premium transport dedicated to Spanish military personnel stationed in Slovakia. Fast transfers from Lešť base to Zvolen and Banská Bystrica with safe returns back to duty.',
+      'Premium transport dedicated to Spanish military personnel stationed in Slovakia. Fast transfers from the Slavia 1 call point at Lešť base to Zvolen and Banská Bystrica with safe returns back to duty.',
     descriptionHighlight: 'Service available in English and Spanish on request.',
     stats: [
       {
@@ -36,11 +36,11 @@ const translations = {
     ],
   },
   es: {
-    routeBadge: '🇪🇸 Base de adiestramiento Lešť → Zvolen / Banská Bystrica',
+    routeBadge: '🇪🇸 Base de Lešť Slavia 1 → Zvolen / Banská Bystrica',
     serviceBadge: 'Aprobado por la OTAN • Discreto 24/7',
     heading: 'TaxiForce Traslados Militares',
     description:
-      'Transporte premium dedicado al personal militar español destacado en Eslovaquia. Traslados rápidos desde la base de Lešť a Zvolen y Banská Bystrica con retornos seguros al servicio.',
+      'Transporte premium dedicado al personal militar español destacado en Eslovaquia. Traslados rápidos desde el punto de llamada Slavia 1 de la base de Lešť a Zvolen y Banská Bystrica con retornos seguros al servicio.',
     descriptionHighlight: 'Servicio disponible en inglés y español bajo solicitud.',
     stats: [
       {

--- a/src/components/RouteSection.tsx
+++ b/src/components/RouteSection.tsx
@@ -13,7 +13,7 @@ const translations = {
         title: 'Lešť → Zvolen',
         duration: '35 min',
         highlights: [
-          'Direct entry at the military gate',
+          'Direct entry at the Slavia 1 military gate',
           'Coordinated pick-up without unnecessary waiting',
           'Recommended bars: Quadra, Retro',
         ],
@@ -36,7 +36,7 @@ const translations = {
       },
       {
         title: '2. Pick-up',
-        detail: 'Driver waits at the Lešť gate. We track unit schedule changes in real time.',
+        detail: 'Driver waits at the Slavia 1 gate inside Lešť. We track unit schedule changes in real time.',
         sub: 'Vehicle and driver identification in advance',
       },
       {
@@ -56,7 +56,7 @@ const translations = {
         title: 'Lešť → Zvolen',
         duration: '35 min',
         highlights: [
-          'Acceso directo por la puerta militar',
+          'Acceso directo por la puerta militar Slavia 1',
           'Recogida coordinada sin esperas innecesarias',
           'Bares recomendados: Quadra, Retro',
         ],
@@ -79,7 +79,7 @@ const translations = {
       },
       {
         title: '2. Recogida',
-        detail: 'El conductor espera en la puerta de Lešť. Seguimos cambios en el programa en tiempo real.',
+        detail: 'El conductor espera en la puerta Slavia 1 de Lešť. Seguimos cambios en el programa en tiempo real.',
         sub: 'Identificación del vehículo y conductor por adelantado',
       },
       {

--- a/src/components/SeoContentSection.tsx
+++ b/src/components/SeoContentSection.tsx
@@ -15,9 +15,9 @@ const translations: Record<
   }
 > = {
   en: {
-    heading: 'Taxi for Spanish troops from Lešť base',
+    heading: 'Taxi for Spanish troops from Lešť base (Slavia 1)',
     intro:
-      'TaxiForce is a specialised transfer service based in central Slovakia. Since 2022 we have ensured safe and comfortable links between the Lešť training area, the city of Zvolen and Banská Bystrica.',
+      'TaxiForce is a specialised transfer service based in central Slovakia. Since 2022 we have ensured safe and comfortable links between the Lešť training area, the Slavia 1 call point, the city of Zvolen and Banská Bystrica.',
     sections: [
       {
         title: 'Professional focus on NATO missions',
@@ -36,7 +36,7 @@ const translations: Record<
         paragraphs: [
           (
             <>
-              TaxiForce targets key phrases such as <strong>taxi Lešť Zvolen</strong>, <strong>military taxi Slovakia</strong>, <strong>transport Spanish Army Slovakia</strong> and <strong>Lešť Banská Bystrica transfer</strong>. With optimised content, reviews and rapid contact, we provide a trusted logistics partner for international units in Slovakia.
+              TaxiForce targets key phrases such as <strong>taxi Lešť Zvolen</strong>, <strong>military taxi Slovakia</strong>, <strong>transport Spanish Army Slovakia</strong>, <strong>Lešť Banská Bystrica transfer</strong> and <strong>Slavia 1 taxi pickup</strong>. With optimised content, reviews and rapid contact, we provide a trusted logistics partner for international units in Slovakia.
             </>
           ),
         ],
@@ -44,9 +44,9 @@ const translations: Record<
     ],
   },
   es: {
-    heading: 'Taxi para las tropas españolas desde la base de Lešť',
+    heading: 'Taxi para las tropas españolas desde la base de Lešť (Slavia 1)',
     intro:
-      'TaxiForce es un servicio de traslados especializado con base en el centro de Eslovaquia. Desde 2022 garantizamos conexiones seguras y cómodas entre el área de entrenamiento de Lešť, la ciudad de Zvolen y Banská Bystrica.',
+      'TaxiForce es un servicio de traslados especializado con base en el centro de Eslovaquia. Desde 2022 garantizamos conexiones seguras y cómodas entre el área de entrenamiento de Lešť, el punto de llamada Slavia 1, la ciudad de Zvolen y Banská Bystrica.',
     sections: [
       {
         title: 'Profesionalidad enfocada en misiones de la OTAN',
@@ -65,7 +65,7 @@ const translations: Record<
         paragraphs: [
           (
             <>
-              TaxiForce trabaja palabras clave como <strong>taxi Lešť Zvolen</strong>, <strong>military taxi Slovakia</strong>, <strong>transport Spanish Army Slovakia</strong> y <strong>Lešť Banská Bystrica transfer</strong>. Con contenido optimizado, reseñas y contacto inmediato, ofrecemos un socio logístico fiable para unidades internacionales en Eslovaquia.
+              TaxiForce trabaja palabras clave como <strong>taxi Lešť Zvolen</strong>, <strong>military taxi Slovakia</strong>, <strong>transport Spanish Army Slovakia</strong>, <strong>Lešť Banská Bystrica transfer</strong> y <strong>taxi Slavia 1 base</strong>. Con contenido optimizado, reseñas y contacto inmediato, ofrecemos un socio logístico fiable para unidades internacionales en Eslovaquia.
             </>
           ),
         ],


### PR DESCRIPTION
## Summary
- highlight the Slavia 1 call point across hero, features, routes and FAQ content in both languages so riders know where transfers originate
- enrich the SEO-focused copy with Slavia 1 mentions and new keyword targets for English and Spanish sections
- update site meta, social and schema descriptions to reference Slavia 1 and improve keyword coverage

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d52ac16c7083238eb2a0b09d5f424f