### PR TITLE
Add modern visual effects and animations

### DIFF
--- a/src/components/FeaturesSection.tsx
+++ b/src/components/FeaturesSection.tsx
@@ -123,10 +123,10 @@ const FeaturesSection = () => {
   const content = translations[language];
 
   return (
-    <section className="py-12 sm:py-20 px-4 sm:px-6 bg-gradient-to-b from-background to-muted">
+    <section className="py-12 sm:py-20 px-4 sm:px-6 bg-gradient-to-b from-background to-muted relative overflow-hidden">
       <div className="max-w-7xl mx-auto">
-        <div className="text-center mb-10 sm:mb-16">
-          <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-4 text-gradient-gold">
+        <div className="text-center mb-10 sm:mb-16 fade-in">
+          <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold mb-4 text-gradient-gold glitch-text">
             {content.heading}
           </h2>
           <p className="text-base sm:text-lg md:text-xl text-muted-foreground max-w-3xl mx-auto">
@@ -139,9 +139,7 @@ const FeaturesSection = () => {
             <Card
               key={feature.title}
               className="
-                relative bg-card/60 backdrop-blur-md border-border/50
-                hover:border-secondary/60 transition-all duration-300
-                hover-military slide-up group overflow-hidden
+                relative glass-card hover-scale group overflow-hidden fade-in
               "
               style={{ animationDelay: `${index * 0.1}s` }}
             >
@@ -154,7 +152,7 @@ const FeaturesSection = () => {
               <CardContent className="p-4 sm:p-5 lg:p-6 space-y-3 sm:space-y-4">
                 {feature.image && (
                   <div
-                    className="w-full h-24 sm:h-28 md:h-32 bg-cover bg-center rounded-lg border border-secondary/20"
+                    className="w-full h-24 sm:h-28 md:h-32 bg-cover bg-center rounded-lg gradient-border skeleton"
                     style={{ backgroundImage: `url(${feature.image})` }}
                   />
                 )}

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import heroImage from '@/assets/hero-military.jpg';
 import { useLanguage } from '@/contexts/LanguageContext';
@@ -72,10 +73,41 @@ const translations = {
 const HeroSection = () => {
   const { language } = useLanguage();
   const content = translations[language];
+  const particlesContainerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const container = particlesContainerRef.current;
+    if (!container) {
+      return undefined;
+    }
+
+    container.innerHTML = '';
+    const particleCount = 60;
+    const createdParticles: HTMLDivElement[] = [];
+
+    for (let index = 0; index < particleCount; index += 1) {
+      const particle = document.createElement('div');
+      particle.className = 'particle';
+      particle.style.left = `${Math.random() * 100}%`;
+      particle.style.animationDelay = `${Math.random() * 20}s`;
+      particle.style.animationDuration = `${15 + Math.random() * 10}s`;
+      particle.style.color = index % 2 === 0 ? 'rgba(255, 255, 255, 0.6)' : 'rgba(255, 200, 0, 0.6)';
+      container.appendChild(particle);
+      createdParticles.push(particle);
+    }
+
+    return () => {
+      createdParticles.forEach((particle) => {
+        if (particle.parentNode === container) {
+          container.removeChild(particle);
+        }
+      });
+    };
+  }, []);
 
   return (
     <section
-      className="relative min-h-[85vh] sm:min-h-screen flex items-center justify-center text-center bg-hero-pattern"
+      className="relative min-h-[85vh] sm:min-h-screen flex items-center justify-center text-center bg-hero-pattern parallax-container"
       style={{
         backgroundImage: `
           linear-gradient(rgba(10, 10, 10, 0.75), rgba(10, 10, 10, 0.85)),
@@ -86,33 +118,37 @@ const HeroSection = () => {
         backgroundAttachment: 'fixed',
       }}
     >
-      <div className="absolute inset-0 bg-gradient-to-b from-black/40 via-black/50 to-black/80" />
+      <div ref={particlesContainerRef} className="particles-container" aria-hidden />
 
-      <div className="relative z-10 max-w-5xl px-4 py-16 sm:px-6 sm:py-20">
-        <div className="flex flex-wrap items-center justify-center gap-3 mb-8">
-          <span className="bg-gradient-to-r from-primary to-secondary px-3 py-2 rounded-full text-[11px] sm:text-sm font-bold uppercase tracking-wide shadow-lg">
-            {content.routeBadge}
-          </span>
-          <span className="bg-secondary/10 border border-secondary/40 text-secondary px-3 py-1 rounded-full text-[11px] sm:text-sm font-semibold backdrop-blur">
+      <div className="absolute inset-0 bg-gradient-to-b from-black/40 via-black/50 to-black/80 parallax-element" data-speed="0.15" />
+
+      <div className="relative z-10 max-w-5xl px-4 py-16 sm:px-6 sm:py-20 space-y-8 fade-in">
+        <div className="flex flex-wrap items-center justify-center gap-3">
+          <span
+            className="typewriter glass-card gradient-border px-4 py-2 rounded-full text-[11px] sm:text-sm font-bold uppercase tracking-wide shadow-lg"
+            data-text={content.routeBadge}
+          />
+          <span className="glass-card flex items-center gap-2 px-3 py-1 rounded-full text-[11px] sm:text-sm font-semibold text-secondary">
+            <span className="pulse-dot bg-secondary" />
             {content.serviceBadge}
           </span>
         </div>
 
-        <h1 className="text-3xl sm:text-5xl md:text-6xl xl:text-7xl font-black mb-5 sm:mb-6 text-gradient-military drop-shadow-2xl leading-tight">
+        <h1 className="glitch-text text-3xl sm:text-5xl md:text-6xl xl:text-7xl font-black drop-shadow-2xl leading-tight fade-in" data-speed="0.25">
           {content.heading}
         </h1>
 
-        <p className="text-base sm:text-lg md:text-2xl mb-8 sm:mb-10 text-foreground/90 max-w-3xl mx-auto leading-relaxed">
+        <p className="text-base sm:text-lg md:text-2xl text-foreground/90 max-w-3xl mx-auto leading-relaxed fade-in">
           {content.description}
           <br className="hidden md:block" />
           <span className="text-secondary font-semibold">{content.descriptionHighlight}</span>
         </p>
 
-        <div className="grid grid-cols-1 min-[380px]:grid-cols-2 sm:grid-cols-3 gap-3 sm:gap-4 mb-8 sm:mb-10 text-left text-xs sm:text-sm">
+        <div className="grid grid-cols-1 min-[380px]:grid-cols-2 sm:grid-cols-3 gap-3 sm:gap-4 text-left text-xs sm:text-sm">
           {content.stats.map((item, index) => (
             <div
               key={item.title}
-              className="bg-black/30 border border-secondary/20 rounded-xl p-3 sm:p-4 backdrop-blur hover:border-secondary/40 transition-all duration-300"
+              className="glass-card gradient-border hover-scale rounded-xl p-3 sm:p-4 fade-in"
               style={{ animationDelay: `${index * 0.1}s` }}
             >
               <p className="text-secondary text-[10px] sm:text-xs uppercase tracking-wide mb-1">{item.title}</p>
@@ -122,11 +158,11 @@ const HeroSection = () => {
           ))}
         </div>
 
-        <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
+        <div className="flex flex-col sm:flex-row gap-4 justify-center items-center fade-in">
           <Button
             size="lg"
             className="
-              bg-gradient-to-r from-primary to-primary-glow
+              button-3d magnetic-button bg-gradient-to-r from-primary to-primary-glow
               hover:from-primary-glow hover:to-primary
               text-primary-foreground px-6 py-3 text-base sm:text-lg font-semibold
               rounded-full shadow-xl
@@ -141,7 +177,7 @@ const HeroSection = () => {
           <Button
             size="lg"
             className="
-              bg-[#25D366] text-white
+              button-3d magnetic-button bg-[#25D366] text-white
               hover:bg-[#1ebe5d]
               px-6 py-3 text-base sm:text-lg font-semibold rounded-full
               shadow-xl transition-all duration-300
@@ -154,11 +190,11 @@ const HeroSection = () => {
           </Button>
         </div>
 
-        <div className="mt-10 sm:mt-12 flex flex-wrap justify-center gap-3 sm:gap-4 text-[11px] sm:text-xs md:text-sm text-muted-foreground">
+        <div className="mt-10 sm:mt-12 flex flex-wrap justify-center gap-3 sm:gap-4 text-[11px] sm:text-xs md:text-sm text-muted-foreground fade-in">
           {content.badges.map((badge) => (
             <div
               key={badge.text}
-              className="flex items-center gap-2 bg-black/40 border border-secondary/20 rounded-full px-3 py-2"
+              className="flex items-center gap-2 glass-card rounded-full px-3 py-2 hover-scale"
             >
               <span>{badge.icon}</span> <span>{badge.text}</span>
             </div>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,22 +1,51 @@
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { FileText } from 'lucide-react';
 import LanguageSwitcher from '@/components/LanguageSwitcher';
 
 const Navigation = () => {
+  const [isVisible, setIsVisible] = useState(true);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined;
+    }
+
+    let lastScroll = 0;
+
+    const handleScroll = () => {
+      const currentScroll = window.pageYOffset;
+      if (currentScroll > lastScroll && currentScroll > 80) {
+        setIsVisible(false);
+      } else {
+        setIsVisible(true);
+      }
+      lastScroll = currentScroll;
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
   return (
-    <nav className="fixed top-4 right-4 z-50 flex items-center gap-3">
+    <nav className={`fixed top-4 right-4 z-50 flex items-center gap-3 ${isVisible ? 'nav-visible' : 'nav-hidden'}`}>
       <Link to="/blog">
-        <Button 
-          variant="ghost" 
-          size="sm" 
-          className="rounded-full bg-black/70 backdrop-blur text-white hover:bg-white/10 px-3 py-2"
+        <Button
+          variant="ghost"
+          size="sm"
+          className="rounded-full glass-card hover-scale text-white px-3 py-2 transition-all"
         >
           <FileText className="w-4 h-4 mr-2" />
           Blog
         </Button>
       </Link>
-      <LanguageSwitcher />
+      <div className="glass-card rounded-full px-2 py-1 hover-scale">
+        <LanguageSwitcher />
+      </div>
     </nav>
   );
 };

--- a/src/components/OperationsSection.tsx
+++ b/src/components/OperationsSection.tsx
@@ -7,19 +7,26 @@ const translations = {
       'We combine military-grade logistics with the comfort of a private chauffeur service. Every deployment is planned in detail.',
     metrics: [
       {
-        value: '4.9/5',
+        value: '4.9',
+        suffix: '/5',
         label: 'Spanish contingent rating',
         detail: 'Based on real feedback reports after night deployments',
+        target: 4.9,
+        decimals: 1,
       },
       {
-        value: '120+',
+        value: '120',
+        suffix: '+',
         label: 'monthly transfers',
         detail: 'Dedicated driver roster with reinforcements during exercises',
+        target: 120,
       },
       {
-        value: '0 incidents',
-        label: 'in 24 months of service',
+        value: '24',
+        suffix: ' months',
+        label: 'continuous service without incidents',
         detail: 'Strict compliance with NATO security protocols and local law',
+        target: 24,
       },
     ],
     pillars: [
@@ -49,19 +56,26 @@ const translations = {
       'Combinamos logística de nivel militar con el confort de un servicio de chofer privado. Cada despliegue se planifica al detalle.',
     metrics: [
       {
-        value: '4.9/5',
+        value: '4.9',
+        suffix: '/5',
         label: 'Valoración del contingente español',
         detail: 'Basada en informes reales tras salidas nocturnas',
+        target: 4.9,
+        decimals: 1,
       },
       {
-        value: '120+',
+        value: '120',
+        suffix: '+',
         label: 'traslados mensuales',
         detail: 'Equipo fijo de conductores con refuerzos durante ejercicios',
+        target: 120,
       },
       {
-        value: '0 incidentes',
-        label: 'en 24 meses de servicio',
+        value: '24',
+        suffix: ' meses',
+        label: 'servicio continuo sin incidentes',
         detail: 'Cumplimos los protocolos de seguridad OTAN y la normativa local',
+        target: 24,
       },
     ],
     pillars: [
@@ -92,10 +106,10 @@ const OperationsSection = () => {
   const content = translations[language];
 
   return (
-    <section className="py-12 sm:py-20 px-4 sm:px-6 bg-gradient-to-b from-black/60 via-background to-black/60">
+    <section className="py-12 sm:py-20 px-4 sm:px-6 bg-gradient-to-b from-black/60 via-background to-black/60 relative overflow-hidden">
       <div className="max-w-6xl mx-auto space-y-10 sm:space-y-16">
-        <div className="text-center space-y-3 sm:space-y-4">
-          <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold text-gradient-gold">
+        <div className="text-center space-y-3 sm:space-y-4 fade-in">
+          <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold text-gradient-gold glitch-text">
             {content.heading}
           </h2>
           <p className="text-base sm:text-lg text-muted-foreground max-w-3xl mx-auto">
@@ -107,9 +121,17 @@ const OperationsSection = () => {
           {content.metrics.map((metric) => (
             <div
               key={metric.label}
-              className="text-center bg-primary/10 border border-primary/30 rounded-2xl px-4 py-6 sm:px-5 sm:py-8 md:px-6 md:py-10 backdrop-blur hover:border-primary/60 transition-all"
+              className="text-center glass-card gradient-border rounded-2xl px-4 py-6 sm:px-5 sm:py-8 md:px-6 md:py-10 hover-scale fade-in"
             >
-              <p className="text-2xl sm:text-3xl md:text-5xl font-black text-gradient-military mb-2">{metric.value}</p>
+              <p
+                className="counter text-2xl sm:text-3xl md:text-5xl font-black text-gradient-military mb-2"
+                data-target={metric.target}
+                data-suffix={metric.suffix ?? ''}
+                data-prefix={metric.prefix ?? ''}
+                data-decimals={metric.decimals ?? 0}
+              >
+                {`${metric.prefix ?? ''}${metric.value}${metric.suffix ?? ''}`}
+              </p>
               <p className="text-[11px] sm:text-sm uppercase tracking-wide text-secondary mb-2">{metric.label}</p>
               <p className="text-[11px] sm:text-xs text-muted-foreground leading-relaxed">{metric.detail}</p>
             </div>
@@ -120,7 +142,7 @@ const OperationsSection = () => {
           {content.pillars.map((pillar) => (
             <div
               key={pillar.title}
-              className="bg-card/70 border border-secondary/20 rounded-2xl p-4 sm:p-5 md:p-6 space-y-3 sm:space-y-4 backdrop-blur hover:border-secondary/50 transition-all"
+              className="neumorphic rounded-2xl p-4 sm:p-5 md:p-6 space-y-3 sm:space-y-4 hover-scale fade-in"
             >
               <div className="text-3xl sm:text-4xl">{pillar.icon}</div>
               <h3 className="text-lg sm:text-xl font-semibold text-secondary">{pillar.title}</h3>

--- a/src/hooks/use-visual-effects.ts
+++ b/src/hooks/use-visual-effects.ts
@@ -1,0 +1,170 @@
+import { useEffect } from 'react';
+
+const useVisualEffects = (dependencies: unknown[] = []) => {
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const elements = document.querySelectorAll<HTMLElement>('.fade-in');
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('visible');
+          }
+        });
+      },
+      {
+        threshold: 0.1,
+        rootMargin: '0px 0px -100px 0px',
+      },
+    );
+
+    elements.forEach((element) => observer.observe(element));
+
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const counters = Array.from(document.querySelectorAll<HTMLElement>('.counter'));
+
+    const handleCounter = (entry: IntersectionObserverEntry, element: HTMLElement) => {
+      const targetValue = Number(element.dataset.target ?? 0);
+      const duration = Number(element.dataset.duration ?? 2000);
+      const decimals = Number(element.dataset.decimals ?? 0);
+      const suffix = element.dataset.suffix ?? '';
+      const prefix = element.dataset.prefix ?? '';
+      let start = 0;
+      const increment = targetValue / (duration / 16);
+
+      const updateCounter = () => {
+        start += increment;
+        if (start < targetValue) {
+          element.textContent = `${prefix}${start.toFixed(decimals)}${suffix}`;
+          requestAnimationFrame(updateCounter);
+        } else {
+          element.textContent = `${prefix}${targetValue.toFixed(decimals)}${suffix}`;
+        }
+      };
+
+      updateCounter();
+    };
+
+    const counterObserver = new IntersectionObserver(
+      (entries, observerInstance) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            const element = entry.target as HTMLElement;
+            handleCounter(entry, element);
+            observerInstance.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.4 },
+    );
+
+    counters.forEach((counter) => {
+      counterObserver.observe(counter);
+    });
+
+    return () => {
+      counterObserver.disconnect();
+    };
+  }, dependencies);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const typewriterElements = Array.from(document.querySelectorAll<HTMLElement>('.typewriter'));
+    const timers: number[] = [];
+
+    typewriterElements.forEach((element) => {
+      const text = element.dataset.text ?? element.textContent ?? '';
+      element.textContent = '';
+      let index = 0;
+
+      const type = () => {
+        if (index < text.length) {
+          element.textContent = `${element.textContent ?? ''}${text.charAt(index)}`;
+          index += 1;
+          const timeout = window.setTimeout(type, 90);
+          timers.push(timeout);
+        }
+      };
+
+      type();
+    });
+
+    return () => {
+      timers.forEach((timer) => window.clearTimeout(timer));
+    };
+  }, dependencies);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const parallaxElements = Array.from(document.querySelectorAll<HTMLElement>('.parallax-element'));
+
+    const handleScroll = () => {
+      const scrolled = window.pageYOffset;
+      parallaxElements.forEach((element) => {
+        const speed = Number(element.dataset.speed ?? 0.5);
+        const yPos = -(scrolled * speed);
+        element.style.transform = `translateY(${yPos}px)`;
+      });
+    };
+
+    handleScroll();
+    window.addEventListener('scroll', handleScroll, { passive: true });
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const magneticButtons = Array.from(document.querySelectorAll<HTMLElement>('.magnetic-button'));
+
+    const handleMouseMove = (event: MouseEvent) => {
+      const target = event.currentTarget as HTMLElement;
+      const rect = target.getBoundingClientRect();
+      const x = event.clientX - rect.left - rect.width / 2;
+      const y = event.clientY - rect.top - rect.height / 2;
+      target.style.transform = `translate(${x * 0.3}px, ${y * 0.3}px)`;
+    };
+
+    const resetTransform = (event: MouseEvent) => {
+      const target = event.currentTarget as HTMLElement;
+      target.style.transform = 'translate(0, 0)';
+    };
+
+    magneticButtons.forEach((button) => {
+      button.addEventListener('mousemove', handleMouseMove);
+      button.addEventListener('mouseleave', resetTransform);
+    });
+
+    return () => {
+      magneticButtons.forEach((button) => {
+        button.removeEventListener('mousemove', handleMouseMove);
+        button.removeEventListener('mouseleave', resetTransform);
+      });
+    };
+  }, []);
+};
+
+export default useVisualEffects;

--- a/src/index.css
+++ b/src/index.css
@@ -176,6 +176,17 @@ All colors MUST be HSL. Spanish flag inspired: Red (#C41C24) + Gold (#FFC400)
     @apply transition-all duration-300 hover:shadow-[0_0_40px_hsl(var(--primary-glow)/0.4)] hover:-translate-y-1;
   }
 
+  .hover-scale {
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  .hover-scale:hover {
+    transform: translateY(-5px) scale(1.02);
+    box-shadow:
+      0 20px 40px rgba(0, 0, 0, 0.2),
+      0 15px 12px rgba(0, 0, 0, 0.15);
+  }
+
   .text-gradient-military {
     background: var(--gradient-military);
     background-clip: text;
@@ -199,4 +210,240 @@ All colors MUST be HSL. Spanish flag inspired: Red (#C41C24) + Gold (#FFC400)
   .spanish-flag-border {
     border-image: linear-gradient(90deg, hsl(var(--primary)) 33%, hsl(var(--secondary)) 33%, hsl(var(--secondary)) 66%, hsl(var(--primary)) 66%) 1;
   }
+}
+
+.glass-card {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.04));
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 20px;
+  box-shadow: 0 8px 32px 0 rgba(31, 38, 135, 0.37);
+}
+
+.particles-container {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.particle {
+  position: absolute;
+  width: 4px;
+  height: 4px;
+  background: currentColor;
+  border-radius: 50%;
+  opacity: 0.3;
+  animation: floatUp 20s infinite linear;
+}
+
+@keyframes floatUp {
+  from {
+    transform: translateY(100vh) translateX(0);
+    opacity: 0;
+  }
+  10% {
+    opacity: 0.3;
+  }
+  90% {
+    opacity: 0.3;
+  }
+  to {
+    transform: translateY(-10vh) translateX(120px);
+    opacity: 0;
+  }
+}
+
+.glitch-text {
+  position: relative;
+  animation: glitch 3s infinite;
+}
+
+@keyframes glitch {
+  0%,
+  100% {
+    text-shadow:
+      0.05em 0 0 rgba(255, 0, 0, 0.75),
+      -0.05em -0.025em 0 rgba(0, 255, 0, 0.75),
+      0.025em 0.05em 0 rgba(0, 0, 255, 0.75);
+  }
+  14%,
+  86% {
+    text-shadow:
+      0.05em 0 0 rgba(255, 0, 0, 0.75),
+      -0.05em -0.025em 0 rgba(0, 255, 0, 0.75),
+      0.025em 0.05em 0 rgba(0, 0, 255, 0.75);
+  }
+  15%,
+  85% {
+    text-shadow: none;
+  }
+}
+
+.pulse-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(255, 196, 0, 0.7);
+  }
+  70% {
+    box-shadow: 0 0 0 10px rgba(255, 196, 0, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(255, 196, 0, 0);
+  }
+}
+
+.button-3d {
+  cursor: pointer;
+  position: relative;
+  transform-style: preserve-3d;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  box-shadow:
+    0 10px 20px rgba(0, 0, 0, 0.2),
+    0 6px 6px rgba(0, 0, 0, 0.15);
+}
+
+.button-3d:hover {
+  transform: translateY(-3px) rotateX(-10deg);
+  box-shadow:
+    0 15px 30px rgba(0, 0, 0, 0.3),
+    0 10px 15px rgba(0, 0, 0, 0.2);
+}
+
+.button-3d:active {
+  transform: translateY(0);
+  box-shadow:
+    0 5px 10px rgba(0, 0, 0, 0.2),
+    0 3px 3px rgba(0, 0, 0, 0.15);
+}
+
+.neumorphic {
+  border-radius: 12px;
+  background: linear-gradient(145deg, #e6e6e6, #ffffff);
+  box-shadow:
+    20px 20px 60px #d1d1d1,
+    -20px -20px 60px #ffffff;
+}
+
+.neumorphic-inset {
+  border-radius: 12px;
+  background: linear-gradient(145deg, #cacaca, #f0f0f0);
+  box-shadow:
+    inset 20px 20px 60px #bebebe,
+    inset -20px -20px 60px #ffffff;
+}
+
+.gradient-border {
+  position: relative;
+  border-radius: 20px;
+  overflow: hidden;
+}
+
+.gradient-border::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: linear-gradient(90deg, transparent, currentColor, transparent);
+  transform: translateX(-100%);
+  transition: transform 0.5s ease;
+}
+
+.gradient-border:hover::before {
+  transform: translateX(100%);
+}
+
+.skeleton {
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.1) 25%,
+    rgba(255, 255, 255, 0.2) 50%,
+    rgba(255, 255, 255, 0.1) 75%
+  );
+  background-size: 200% 100%;
+  animation: loading 1.5s infinite;
+}
+
+@keyframes loading {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+.fade-in {
+  opacity: 0;
+  transform: translateY(30px);
+  transition: all 0.8s ease;
+}
+
+.fade-in.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.parallax-container {
+  position: relative;
+  overflow: hidden;
+}
+
+.parallax-element {
+  will-change: transform;
+  transition: transform 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.typewriter {
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.nav-hidden {
+  transform: translateY(-120%);
+  transition: transform 0.3s ease;
+}
+
+.nav-visible {
+  transform: translateY(0);
+  transition: transform 0.3s ease;
+}
+
+.magnetic-button {
+  position: relative;
+  transition: all 0.2s ease;
+}
+
+.fab {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  cursor: pointer;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+  transition: all 0.3s ease;
+  z-index: 999;
+}
+
+.fab:hover {
+  transform: scale(1.1) rotate(90deg);
+  box-shadow: 0 15px 40px rgba(0, 0, 0, 0.4);
+}
+
+.fab:active {
+  transform: scale(0.95);
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -8,10 +8,15 @@ import FaqSection from '@/components/FaqSection';
 import SeoContentSection from '@/components/SeoContentSection';
 import ContactSection from '@/components/ContactSection';
 import Navigation from '@/components/Navigation';
+import { useLanguage } from '@/contexts/LanguageContext';
+import useVisualEffects from '@/hooks/use-visual-effects';
 
 const Index = () => {
+  const { language } = useLanguage();
+  useVisualEffects([language]);
+
   return (
-    <div className="min-h-screen bg-background">
+    <div className="min-h-screen bg-background relative overflow-hidden">
       <Navigation />
       <main>
         <HeroSection />
@@ -24,6 +29,13 @@ const Index = () => {
         <SeoContentSection />
         <ContactSection />
       </main>
+      <a
+        href="tel:+421919040118"
+        className="fab button-3d magnetic-button bg-gradient-to-br from-primary to-secondary text-primary-foreground flex items-center justify-center text-2xl"
+        aria-label="Zavolať TaxiForce"
+      >
+        📞
+      </a>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add glassmorphism hero layout with animated particles, glitch typography, and dynamic call-to-actions
- introduce a reusable visual effects hook driving fade-ins, counters, parallax, typewriter, and magnetic button behaviour
- refresh feature and operations sections with gradient borders, neumorphic surfaces, and animated statistics plus floating action button

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d622434de08323981d37d38a10c914